### PR TITLE
Community: Add All-Contributors Bot

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,18 @@
+{
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "contributorsPerLine": 7,
+  "contributorsSortAlphabetically": false,
+  "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg)](#contributors)",
+  "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
+  "types": {
+    "custom": {
+      "symbol": "🔭",
+      "description": "A custom contribution type."
+    }
+  },
+  "skipCi": true,
+  "contributors": []
+}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ cargo build --target wasm32-unknown-unknown --release
 
 Contributions are welcome! Please fork the repository and submit a pull request.
 
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Add `.all-contributorsrc` configuration file for the All-Contributors bot
- Add Contributors table section to README.md

## Context
This PR sets up the repository configuration for the All-Contributors bot, which recognizes all types of contributions (code, design, docs, etc.) and encourages community participation by giving credit.

## Acceptance Criteria
- [x] Add `.all-contributorsrc` config
- [x] Add Contributors table to README

**Note:** The All-Contributors bot needs to be installed from GitHub Marketplace by a repository maintainer.

Closes #88