### PR TITLE
feat(stream_contract): implement overflow-safe withdraw calculation l…

### DIFF
--- a/contracts/stream_contract/src/lib.rs
+++ b/contracts/stream_contract/src/lib.rs
@@ -1,6 +1,10 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, Symbol, symbol_short, token};
 
+
+
+
+
 #[derive(Clone)]
 #[contracttype]
 pub struct Stream {
@@ -63,6 +67,43 @@ pub struct StreamToppedUpEvent {
     pub new_deposited_amount: i128,
 }
 
+pub fn calculate_claimable(stream: &Stream, now: u64) -> Result<i128, StreamError> {
+    // If stream inactive, nothing claimable
+    if !stream.is_active {
+        return Err(StreamError::StreamInactive);
+    }
+
+    // No time passed
+    if now <= stream.last_update_time {
+        return Ok(0);
+    }
+
+    // Safe time difference
+    let elapsed = now
+        .checked_sub(stream.last_update_time)
+        .ok_or(StreamError::InvalidAmount)? as i128;
+
+    // Safe multiplication (overflow protected)
+    let accrued = elapsed
+        .checked_mul(stream.rate_per_second)
+        .ok_or(StreamError::InvalidAmount)?;
+
+    // Remaining available balance
+    let available = stream
+        .deposited_amount
+        .checked_sub(stream.withdrawn_amount)
+        .ok_or(StreamError::InvalidAmount)?;
+
+    // Cannot withdraw more than deposited
+    Ok(accrued.min(available))
+}
+
+#[contracttype]
+pub enum DataKey {
+    StreamCounter,
+    Stream(u64),
+}
+
 #[contract]
 pub struct StreamContract;
 
@@ -92,11 +133,12 @@ impl StreamContract {
                 stream_id,
                 sender: sender.clone(),
                 recipient: recipient.clone(),
-                rate,
+                rate: amount,
                 token_address: token_address.clone(),
                 start_time,
             }
         );
+        stream_id
     }
 
     fn get_next_stream_id(env: &Env) -> u64 {
@@ -111,8 +153,9 @@ impl StreamContract {
             .set(&DataKey::StreamCounter, &next_id);
         next_id
     }
-
-    pub fn withdraw(_env: Env, _recipient: Address, _stream_id: u64) {
+     
+      pub fn withdraw(env: Env, recipient: Address, stream_id: u64)
+     {
         // Placeholder for withdraw logic
         // 1. Calculate claimable amount based on time delta
         // 2. Transfer tokens to recipient
@@ -157,61 +200,9 @@ impl StreamContract {
         );
     }
 
-    /// Allows the sender to add more funds to an existing stream
-    /// This extends the duration of the stream without creating a new one
-    pub fn top_up_stream(env: Env, sender: Address, stream_id: u64, amount: i128) -> Result<(), StreamError> {
-        // Require sender authentication
-        sender.require_auth();
 
-        // Validate amount is positive
-        if amount <= 0 {
-            return Err(StreamError::InvalidAmount);
-        }
-
-        // Get the stream from storage
-        let storage = env.storage().persistent();
-        let stream_key = (symbol_short!("STREAMS"), stream_id);
-
-        let mut stream: Stream = match storage.get(&stream_key) {
-            Some(s) => s,
-            None => return Err(StreamError::StreamNotFound),
-        };
-
-        // Verify the caller is the original sender
-        if stream.sender != sender {
-            return Err(StreamError::Unauthorized);
-        }
-
-        // Verify stream is still active
-        if !stream.is_active {
-            return Err(StreamError::StreamInactive);
-        }
-
-        // Transfer tokens from sender to contract
-        let token_client = token::Client::new(&env, &stream.token_address);
-        let contract_address = env.current_contract_address();
-        token_client.transfer(&sender, &contract_address, &amount);
-
-        // Update stream state with additional deposit
-        stream.deposited_amount += amount;
-        stream.last_update_time = env.ledger().timestamp();
-
-        // Save updated stream back to storage
-        storage.set(&stream_key, &stream);
-
-        // Emit StreamToppedUp event
-        env.events().publish(
-            (Symbol::new(&env, "stream_topped_up"), stream_id),
-            StreamToppedUpEvent {
-                stream_id,
-                sender: sender.clone(),
-                amount,
-                new_deposited_amount: stream.deposited_amount,
-            }
-        );
-
-        Ok(())
-    }
+    
+     
 
     /// Allows the sender to add more funds to an existing stream
     /// This extends the duration of the stream without creating a new one
@@ -258,10 +249,7 @@ impl StreamContract {
         Ok(())
     }
 
-    pub fn get_stream(env: Env, stream_id: u64) -> Option<Stream> {
-        env.storage().instance().get(&DataKey::Stream(stream_id))
-    }
-
+  
     pub fn get_stream(env: Env, stream_id: u64) -> Option<Stream> {
         env.storage().instance().get(&DataKey::Stream(stream_id))
     }

--- a/contracts/stream_contract/src/test.rs
+++ b/contracts/stream_contract/src/test.rs
@@ -267,3 +267,33 @@ fn test_top_up_stream_inactive() {
     let result = client.try_top_up_stream(&sender, &stream_id, &1_000i128);
     assert_eq!(result, Err(Ok(StreamError::StreamInactive)));
 }
+
+    
+#[test]
+fn test_calculate_claimable() {
+    let env = Env::default();
+
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let stream = Stream {
+        sender,
+        recipient,
+        token_address: token,
+        rate_per_second: 10,
+        deposited_amount: 1000,
+        withdrawn_amount: 0,
+        start_time: 0,
+        last_update_time: 0,
+        is_active: true,
+    };
+
+    let result = calculate_claimable(&stream, 50).unwrap();
+
+    assert_eq!(result, 500); // 50 * 10
+}
+
+
+
+


### PR DESCRIPTION
close#79

This PR implements the withdraw calculation logic requested in Issue #79.

The helper function `calculate_claimable` follows the required formula:
(now - last_update_time) * rate_per_second

It uses checked arithmetic to prevent overflow and ensures integer-only math for deterministic rounding behavior. The result is capped to the available balance to prevent over-withdrawal.

Please let me know if you'd like this logic integrated directly into the `withdraw` function as well.

Thanks!