### PR TITLE
Frontend Integration: Execute Soroban create_stream Transaction #176

### DIFF
--- a/frontend/components/dashboard/dashboard-view.tsx
+++ b/frontend/components/dashboard/dashboard-view.tsx
@@ -316,6 +316,7 @@ export function DashboardView({ session, onDisconnect }: DashboardViewProps) {
   >(null);
   const [streamFormMessage, setStreamFormMessage] =
     React.useState<StreamFormMessageState | null>(null);
+  const [isFormSubmitting, setIsFormSubmitting] = React.useState(false);
 
   // --- Snapshot State (merged) ---
   const [snapshot, setSnapshot] = React.useState<DashboardSnapshot | null>(null);
@@ -556,7 +557,7 @@ export function DashboardView({ session, onDisconnect }: DashboardViewProps) {
     }
   };
 
-  const handleFormCreateStream = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleFormCreateStream = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const hasRequiredFields =
       streamForm.recipient.trim() &&
@@ -573,15 +574,57 @@ export function DashboardView({ session, onDisconnect }: DashboardViewProps) {
       return;
     }
 
-    // Convert StreamFormValues to StreamFormData for handleCreateStream if possible
-    // or just show alert for now as per upstream mock logic
-    alert(
-      `Stream prepared for ${streamForm.recipient} with ${streamForm.totalAmount} ${streamForm.token}. You can still edit any field before final submission integration.`,
-    );
-    setStreamFormMessage({
-      text: "Stream draft is ready for submission integration.",
-      tone: "success",
-    });
+    const recipient = streamForm.recipient.trim();
+    if (!/^G[A-Z0-9]{55}$/.test(recipient)) {
+      setStreamFormMessage({
+        text: "Recipient must be a valid Stellar public key.",
+        tone: "error",
+      });
+      return;
+    }
+
+    const startDate = new Date(streamForm.startsAt);
+    const endDate = new Date(streamForm.endsAt);
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+      setStreamFormMessage({
+        text: "Start and end times must be valid dates.",
+        tone: "error",
+      });
+      return;
+    }
+
+    const durationSeconds = Math.floor((endDate.getTime() - startDate.getTime()) / 1000);
+    if (durationSeconds <= 0) {
+      setStreamFormMessage({
+        text: "End time must be after start time.",
+        tone: "error",
+      });
+      return;
+    }
+
+    setIsFormSubmitting(true);
+    try {
+      await handleCreateStream({
+        recipient,
+        token: streamForm.token.trim(),
+        amount: streamForm.totalAmount.trim(),
+        duration: String(durationSeconds),
+        durationUnit: "seconds",
+      });
+
+      handleResetStreamForm();
+      setStreamFormMessage({
+        text: "Stream submitted to wallet and confirmed on-chain.",
+        tone: "success",
+      });
+    } catch (err) {
+      setStreamFormMessage({
+        text: toSorobanErrorMessage(err),
+        tone: "error",
+      });
+    } finally {
+      setIsFormSubmitting(false);
+    }
   };
 
   // ── Tab content ─────────────────────────────────────────────────────────────
@@ -783,6 +826,89 @@ export function DashboardView({ session, onDisconnect }: DashboardViewProps) {
                       placeholder="USDC"
                     />
                   </label>
+                  <label>
+                    Total Amount
+                    <input
+                      required
+                      type="number"
+                      min="0"
+                      step="0.0000001"
+                      value={streamForm.totalAmount}
+                      onChange={(event) =>
+                        updateStreamForm("totalAmount", event.target.value)
+                      }
+                      placeholder="100"
+                    />
+                  </label>
+                </div>
+
+                <div className="stream-form__row">
+                  <label>
+                    Starts At
+                    <input
+                      required
+                      type="datetime-local"
+                      value={streamForm.startsAt}
+                      onChange={(event) =>
+                        updateStreamForm("startsAt", event.target.value)
+                      }
+                    />
+                  </label>
+                  <label>
+                    Ends At
+                    <input
+                      required
+                      type="datetime-local"
+                      value={streamForm.endsAt}
+                      onChange={(event) =>
+                        updateStreamForm("endsAt", event.target.value)
+                      }
+                    />
+                  </label>
+                </div>
+
+                <div className="stream-form__row">
+                  <label>
+                    Cadence (seconds)
+                    <input
+                      type="number"
+                      min="1"
+                      step="1"
+                      value={streamForm.cadenceSeconds}
+                      onChange={(event) =>
+                        updateStreamForm("cadenceSeconds", event.target.value)
+                      }
+                    />
+                  </label>
+                </div>
+
+                <label>
+                  Note
+                  <textarea
+                    value={streamForm.note}
+                    onChange={(event) =>
+                      updateStreamForm("note", event.target.value)
+                    }
+                    placeholder="Optional internal note for this stream configuration."
+                  />
+                </label>
+
+                <div className="stream-form__actions">
+                  <button
+                    type="submit"
+                    className="wallet-button"
+                    disabled={isFormSubmitting}
+                  >
+                    {isFormSubmitting ? "Submitting..." : "Create Stream"}
+                  </button>
+                  <button
+                    type="button"
+                    className="secondary-button"
+                    disabled={isFormSubmitting}
+                    onClick={handleResetStreamForm}
+                  >
+                    Reset
+                  </button>
                 </div>
               </form>
             </div>


### PR DESCRIPTION
## Description
Connect the dashboard "Create Stream" form to Freighter so form submission signs and submits a Soroban `create_stream` transaction through the existing contract client.

Closes #176

## Changes proposed

### What were you told to do?
I was asked to connect the "Create Stream" UI to the Freighter wallet so that submitting the form prompts wallet signing and submits a `create_stream` transaction to the Soroban smart contract.

### What did I do?

#### Wired dashboard form submission to Soroban/Freighter transaction flow
- Replaced placeholder `alert(...)` behavior in `handleFormCreateStream` with real transaction submission.
- Validates required fields, recipient address format, and start/end datetime order.
- Computes duration in seconds from `startsAt`/`endsAt` and maps form data to the existing `handleCreateStream` contract flow.
- Uses existing Soroban helpers (`toBaseUnits`, `toDurationSeconds`, `getTokenAddress`, `sorobanCreateStream`) so the submit action uses Freighter signing + Soroban submit path.

#### Restored full stream form controls in the Streams tab
- Added/connected fields required for real submission:
  - `Total Amount`
  - `Starts At`
  - `Ends At`
  - `Cadence (seconds)`
  - `Note`
- Added form actions:
  - `Create Stream` submit button
  - `Reset` button
- Added `isFormSubmitting` state to prevent duplicate submissions while wallet/network flow is in progress.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the _main branch_ (left side).
- [x] My commit messages styles matches our requested structure.
- [ ] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
Validated with:
```text
Manual code-path validation of dashboard form -> `handleCreateStream` -> Soroban helper flow.
```

Note: lint/test commands were not executed in this environment because `eslint` was unavailable locally (`sh: eslint: command not found`).
