### PR TITLE
ci: add explicit PR test gate for contracts and backend

### DIFF
--- a/.github/workflows/pr-test-gate.yml
+++ b/.github/workflows/pr-test-gate.yml
@@ -1,0 +1,69 @@
+name: PR Test Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  contracts-test:
+    name: Contracts cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Run cargo test
+        run: cargo test
+        working-directory: contracts
+
+  backend-test:
+    name: Backend npm test
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: flowfi_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --include=optional
+
+      - name: Prepare database schema
+        run: |
+          npx prisma generate --schema=prisma/schema.prisma
+          npx prisma db push --accept-data-loss --schema=prisma/schema.prisma
+        working-directory: backend
+        env:
+          DATABASE_URL: postgresql://postgres:password@127.0.0.1:5432/flowfi_test
+
+      - name: Run backend tests
+        run: npm test
+        working-directory: backend
+        env:
+          DATABASE_URL: postgresql://postgres:password@127.0.0.1:5432/flowfi_test
+          NODE_ENV: test


### PR DESCRIPTION
## Summary
- add a dedicated workflow `.github/workflows/pr-test-gate.yml`
- trigger on `pull_request` to `main`
- install Rust toolchain and run `cargo test` in `contracts/`
- install Node and run backend `npm test` in `backend/` with PostgreSQL service setup

## Scope
- issue focus implemented: `#80`

## Validation
- workflow syntax reviewed in-repo; execution will occur on PR in GitHub Actions

Closes #68
Closes #71
Closes #80
Closes #178
