### PR TITLE
Resolves #228, resolves #229, resolves #230, resolves #231

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -30,3 +30,14 @@ INDEXER_POLL_INTERVAL_MS=5000
 
 # Ledger sequence to start indexing from on first run (0 = latest)
 INDEXER_START_LEDGER=0
+
+# ─── Redis (optional) ────────────────────────────────────────────────────────
+# When set, enables horizontal SSE scaling via Redis pub/sub so events
+# emitted by any backend instance are broadcast to clients on all instances.
+# Leave empty to run in single-instance mode (no Redis required).
+REDIS_URL=
+
+# ─── Admin ───────────────────────────────────────────────────────────────────
+# Bearer token required for GET /v1/admin/metrics.
+# Leave empty to disable the admin endpoint entirely.
+ADMIN_SECRET=

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "express-rate-limit": "^8.2.1",
+    "ioredis": "^5.3.2",
     "pg": "^8.18.0",
     "stellar-sdk": "^13.3.0",
     "swagger-jsdoc": "^6.2.8",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -78,4 +78,6 @@ model StreamEvent {
   @@index([eventType])
   @@index([timestamp])
   @@index([transactionHash])
+  @@index([createdAt])
+  @@index([streamId, createdAt])
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -188,15 +188,31 @@ app.get('/health', async (req: Request, res: Response) => {
     let dbStatus = 'healthy';
     try {
         await prisma.$queryRaw`SELECT 1`;
-    } catch (error) {
+    } catch {
         dbStatus = 'unhealthy';
+    }
+
+    let indexerStatus = 'unknown';
+    let indexerLastLedger: number | null = null;
+    try {
+        const state = await prisma.indexerState.findUnique({ where: { id: 'singleton' } });
+        if (state) {
+            indexerLastLedger = state.lastLedger;
+            indexerStatus = 'running';
+        } else {
+            indexerStatus = 'not_started';
+        }
+    } catch {
+        indexerStatus = 'error';
     }
 
     const status = dbStatus === 'healthy' ? 'healthy' : 'unhealthy';
     res.status(status === 'healthy' ? 200 : 503).json({
         status,
-        timestamp: new Date().toISOString(),
+        db: dbStatus,
+        indexer: { status: indexerStatus, lastLedger: indexerLastLedger },
         uptime: process.uptime(),
+        timestamp: new Date().toISOString(),
         version: '1.0.0',
         apiVersions: {
             supported: ['v1'],

--- a/backend/src/controllers/sse.controller.ts
+++ b/backend/src/controllers/sse.controller.ts
@@ -9,6 +9,10 @@ const subscribeSchema = z.object({
 });
 
 export const subscribe = (req: Request, res: Response) => {
+  if (sseService.isShuttingDown()) {
+    return res.status(503).json({ message: 'Server is shutting down, please reconnect shortly.' });
+  }
+
   try {
     const { streams, users, all } = subscribeSchema.parse(req.query);
     

--- a/backend/src/controllers/stream.controller.ts
+++ b/backend/src/controllers/stream.controller.ts
@@ -103,7 +103,7 @@ export const getStream = async (req: Request, res: Response) => {
 };
 
 /**
- * List events for a stream
+ * List events for a stream (paginated)
  */
 export const getStreamEvents = async (req: Request, res: Response) => {
   try {
@@ -116,12 +116,35 @@ export const getStreamEvents = async (req: Request, res: Response) => {
       return res.status(400).json({ error: 'Invalid streamId parameter' });
     }
 
-    const events = await prisma.streamEvent.findMany({
-      where: { streamId: parsedStreamId },
-      orderBy: { timestamp: 'desc' }
-    });
+    const rawLimit = req.query['limit'];
+    const rawOffset = req.query['offset'];
+    const cursor = typeof req.query['cursor'] === 'string' ? req.query['cursor'] : undefined;
+    const direction = req.query['direction'] === 'asc' ? 'asc' as const : 'desc' as const;
 
-    return res.status(200).json(events);
+    const limit = Math.min(
+      rawLimit && typeof rawLimit === 'string' ? (Number.parseInt(rawLimit, 10) || 50) : 50,
+      500,
+    );
+    const offset =
+      rawOffset && typeof rawOffset === 'string' ? (Number.parseInt(rawOffset, 10) || 0) : 0;
+
+    const [events, total] = await Promise.all([
+      prisma.streamEvent.findMany({
+        where: { streamId: parsedStreamId },
+        orderBy: { createdAt: direction },
+        take: limit,
+        ...(cursor
+          ? { cursor: { id: cursor }, skip: 1 }
+          : { skip: offset }),
+      }),
+      prisma.streamEvent.count({ where: { streamId: parsedStreamId } }),
+    ]);
+
+    const hasMore = cursor
+      ? events.length === limit
+      : offset + events.length < total;
+
+    return res.status(200).json({ data: events, total, hasMore });
   } catch (error) {
     logger.error('Error fetching stream events:', error);
     return res.status(500).json({ error: 'Internal server error' });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,16 +3,23 @@ import app from "./app.js";
 import logger from "./logger.js";
 import { sorobanIndexerService } from "./services/soroban-indexer.service.js";
 import { startWorkers, stopWorkers } from "./workers/index.js";
+import { sseService } from "./services/sse.service.js";
+import { connectRedis, disconnectRedis } from "./lib/redis.js";
 
 dotenv.config();
 
+const SHUTDOWN_TIMEOUT_MS = 30_000;
+
 const startServer = async () => {
   try {
-    // Validate database connectivity
     const { prisma } = await import("./lib/prisma.js");
     await prisma.$connect();
     await prisma.$queryRaw`SELECT 1`;
     logger.info("Database connection established successfully");
+
+    // Connect Redis (graceful fallback to single-instance mode when absent)
+    await connectRedis();
+    await sseService.initRedisSubscription();
 
     const port = process.env.PORT || 3001;
     const server = app.listen(port, () => {
@@ -22,31 +29,65 @@ const startServer = async () => {
       );
     });
 
-    // Start Soroban indexer + background workers after the HTTP server is up.
     sorobanIndexerService.start();
     await startWorkers();
 
-    // Graceful shutdown: stop workers (and indexer) before closing the HTTP server.
-    const shutdown = (signal: string) => {
+    const shutdown = async (signal: string) => {
       logger.info(`Received ${signal}. Shutting down gracefully...`);
+
+      // 1. Notify all active SSE clients to reconnect (sets shuttingDown flag)
+      sseService.sendReconnectToAll();
+
+      // 2. Stop accepting new HTTP connections
+      server.close();
+
+      // 3. Stop indexers (clears poll timers)
       try {
-        // Prefer a stop() if your service exposes it; otherwise remove this.
         sorobanIndexerService.stop?.();
       } catch (err) {
         logger.warn("Error while stopping soroban indexer:", err);
       }
-
       stopWorkers();
-      server.close(() => {
-        logger.info("HTTP server closed.");
-        process.exit(0);
-      });
+
+      // 4. Wait for in-flight indexer batch to finish (max 30s)
+      let exitCode = 0;
+      try {
+        const { sorobanEventWorker } = await import(
+          "./workers/soroban-event-worker.js"
+        );
+        await Promise.race([
+          sorobanEventWorker.waitForDrain(),
+          new Promise<void>((_, reject) =>
+            setTimeout(
+              () => reject(new Error("Indexer drain timeout")),
+              SHUTDOWN_TIMEOUT_MS,
+            ),
+          ),
+        ]);
+        logger.info("Indexer drained successfully.");
+      } catch (err) {
+        logger.warn("Indexer drain timed out:", err);
+        exitCode = 1;
+      }
+
+      // 5. Disconnect Redis
+      await disconnectRedis();
+
+      // 6. Close Prisma DB connection
+      const { prisma: db } = await import("./lib/prisma.js");
+      await db.$disconnect();
+      logger.info("Database connection closed.");
+
+      process.exit(exitCode);
     };
 
-    process.on("SIGTERM", () => shutdown("SIGTERM"));
-    process.on("SIGINT", () => shutdown("SIGINT"));
+    process.on("SIGTERM", () => void shutdown("SIGTERM"));
+    process.on("SIGINT", () => void shutdown("SIGINT"));
   } catch (error) {
-    logger.error("Failed to start server due to database connection error:", error);
+    logger.error(
+      "Failed to start server due to database connection error:",
+      error,
+    );
     process.exit(1);
   }
 };

--- a/backend/src/lib/redis.ts
+++ b/backend/src/lib/redis.ts
@@ -1,0 +1,59 @@
+import Redis from 'ioredis';
+import logger from '../logger.js';
+
+const REDIS_URL = process.env.REDIS_URL;
+
+let _publisher: Redis | null = null;
+let _subscriber: Redis | null = null;
+let _available = false;
+
+export function getPublisher(): Redis | null {
+  return _publisher;
+}
+
+export function getSubscriber(): Redis | null {
+  return _subscriber;
+}
+
+export function isRedisAvailable(): boolean {
+  return _available;
+}
+
+function makeClient(url: string): Redis {
+  return new Redis(url, {
+    maxRetriesPerRequest: 3,
+    retryStrategy: (times) => (times > 3 ? null : Math.min(times * 200, 2000)),
+    enableOfflineQueue: false,
+    lazyConnect: true,
+  });
+}
+
+export async function connectRedis(): Promise<void> {
+  if (!REDIS_URL) {
+    logger.info('[Redis] REDIS_URL not set — running in single-instance SSE mode.');
+    return;
+  }
+
+  try {
+    _publisher = makeClient(REDIS_URL);
+    _subscriber = makeClient(REDIS_URL);
+
+    await Promise.all([_publisher.connect(), _subscriber.connect()]);
+    _available = true;
+    logger.info('[Redis] Connected — horizontal SSE scaling enabled.');
+  } catch (err) {
+    logger.warn('[Redis] Connection failed — falling back to single-instance SSE mode:', err);
+    _publisher?.disconnect();
+    _subscriber?.disconnect();
+    _publisher = null;
+    _subscriber = null;
+    _available = false;
+  }
+}
+
+export async function disconnectRedis(): Promise<void> {
+  await Promise.all([_publisher?.quit(), _subscriber?.quit()]);
+  _publisher = null;
+  _subscriber = null;
+  _available = false;
+}

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -1,0 +1,137 @@
+import { Router } from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import { prisma } from '../lib/prisma.js';
+import { sseService } from '../services/sse.service.js';
+import logger from '../logger.js';
+
+const router = Router();
+
+function adminAuth(req: Request, res: Response, next: NextFunction): void {
+  const secret = process.env.ADMIN_SECRET;
+  if (!secret) {
+    res.status(503).json({ error: 'Admin access not configured on this instance.' });
+    return;
+  }
+  const auth = req.headers.authorization ?? '';
+  if (!auth.startsWith('Bearer ') || auth.slice(7) !== secret) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  next();
+}
+
+/**
+ * @openapi
+ * /v1/admin/metrics:
+ *   get:
+ *     tags:
+ *       - Admin
+ *     summary: Protocol health metrics
+ *     description: |
+ *       Returns detailed protocol health metrics including stream counts, indexer state,
+ *       SSE connection count, and server uptime. Requires admin Bearer token.
+ *     security:
+ *       - adminAuth: []
+ *     responses:
+ *       200:
+ *         description: Protocol health metrics
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 streams:
+ *                   type: object
+ *                   properties:
+ *                     active:
+ *                       type: integer
+ *                     total:
+ *                       type: integer
+ *                     byStatus:
+ *                       type: object
+ *                       properties:
+ *                         active:
+ *                           type: integer
+ *                         cancelled:
+ *                           type: integer
+ *                         completed:
+ *                           type: integer
+ *                 events:
+ *                   type: object
+ *                   properties:
+ *                     last24h:
+ *                       type: integer
+ *                 sse:
+ *                   type: object
+ *                   properties:
+ *                     activeConnections:
+ *                       type: integer
+ *                 indexer:
+ *                   type: object
+ *                   properties:
+ *                     lastLedger:
+ *                       type: integer
+ *                     lagSeconds:
+ *                       type: integer
+ *                       nullable: true
+ *                     lastUpdated:
+ *                       type: string
+ *                       format: date-time
+ *                       nullable: true
+ *                 uptime:
+ *                   type: number
+ *                   description: Server uptime in seconds
+ *       401:
+ *         description: Unauthorized — missing or invalid admin token
+ *       503:
+ *         description: Admin access not configured
+ */
+router.get('/metrics', adminAuth, async (_req: Request, res: Response) => {
+  try {
+    const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const [activeCount, totalCount, cancelledCount, completedCount, eventsLast24h, indexerState] =
+      await Promise.all([
+        prisma.stream.count({ where: { isActive: true } }),
+        prisma.stream.count(),
+        prisma.stream.count({
+          where: { isActive: false, events: { some: { eventType: 'CANCELLED' } } },
+        }),
+        prisma.stream.count({
+          where: { isActive: false, events: { some: { eventType: 'COMPLETED' } } },
+        }),
+        prisma.streamEvent.count({ where: { createdAt: { gte: since24h } } }),
+        prisma.indexerState.findUnique({ where: { id: 'singleton' } }),
+      ]);
+
+    const nowSec = Math.floor(Date.now() / 1000);
+    const lagSeconds = indexerState
+      ? nowSec - Math.floor(indexerState.updatedAt.getTime() / 1000)
+      : null;
+
+    res.json({
+      streams: {
+        active: activeCount,
+        total: totalCount,
+        byStatus: {
+          active: activeCount,
+          cancelled: cancelledCount,
+          completed: completedCount,
+        },
+      },
+      events: { last24h: eventsLast24h },
+      sse: { activeConnections: sseService.getClientCount() },
+      indexer: {
+        lastLedger: indexerState?.lastLedger ?? 0,
+        lagSeconds,
+        lastUpdated: indexerState?.updatedAt ?? null,
+      },
+      uptime: process.uptime(),
+    });
+  } catch (err) {
+    logger.error('Error fetching admin metrics:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/backend/src/routes/v1/index.ts
+++ b/backend/src/routes/v1/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import streamRoutes from './stream.routes.js';
 import eventsRoutes from './events.routes.js';
 import userRoutes from './user.routes.js';
+import adminRoutes from '../adminRoutes.js';
 
 const router = Router();
 
@@ -9,5 +10,6 @@ const router = Router();
 router.use('/streams', streamRoutes);
 router.use('/events', eventsRoutes);
 router.use('/users', userRoutes);
+router.use('/admin', adminRoutes);
 
 export default router;

--- a/backend/src/routes/v1/stream.routes.ts
+++ b/backend/src/routes/v1/stream.routes.ts
@@ -152,8 +152,13 @@ router.get('/:streamId', getStream);
  *   get:
  *     tags:
  *       - Streams
- *     summary: List stream events
- *     description: Retrieve all events associated with a specific stream.
+ *     summary: List stream events (paginated)
+ *     description: |
+ *       Retrieve events for a specific stream with offset- or cursor-based pagination.
+ *
+ *       **Offset pagination:** Use `limit` and `offset`.
+ *       **Cursor pagination:** Use `cursor=<eventId>` and `direction`. The cursor record
+ *       itself is excluded; events immediately after (asc) or before (desc) it are returned.
  *     parameters:
  *       - in: path
  *         name: streamId
@@ -161,15 +166,55 @@ router.get('/:streamId', getStream);
  *         schema:
  *           type: integer
  *         description: On-chain stream ID
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 50
+ *           maximum: 500
+ *         description: Maximum number of events to return (default 50, max 500)
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           default: 0
+ *         description: Number of events to skip (offset pagination)
+ *       - in: query
+ *         name: cursor
+ *         schema:
+ *           type: string
+ *         description: Event ID to use as pagination cursor (cursor-based pagination)
+ *       - in: query
+ *         name: direction
+ *         schema:
+ *           type: string
+ *           enum: [asc, desc]
+ *           default: desc
+ *         description: Sort direction (default desc)
  *     responses:
  *       200:
- *         description: List of stream events
+ *         description: Paginated list of stream events
  *         content:
  *           application/json:
  *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/StreamEvent'
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/StreamEvent'
+ *                 total:
+ *                   type: integer
+ *                   description: Total number of events for this stream
+ *                   example: 120
+ *                 hasMore:
+ *                   type: boolean
+ *                   description: Whether more events exist beyond the current page
+ *                   example: true
+ *       400:
+ *         description: Invalid streamId
+ *       404:
+ *         description: Stream not found
  */
 router.get('/:streamId/events', getStreamEvents);
 

--- a/backend/src/services/sse.service.ts
+++ b/backend/src/services/sse.service.ts
@@ -1,5 +1,6 @@
 import type { Response } from 'express';
 import logger from '../logger.js';
+import { isRedisAvailable, getPublisher, getSubscriber } from '../lib/redis.js';
 
 interface SSEClient {
   id: string;
@@ -9,6 +10,32 @@ interface SSEClient {
 
 class SSEService {
   private clients: Map<string, SSEClient> = new Map();
+  private shuttingDown = false;
+
+  isShuttingDown(): boolean {
+    return this.shuttingDown;
+  }
+
+  async initRedisSubscription(): Promise<void> {
+    const sub = getSubscriber();
+    if (!sub) return;
+
+    await sub.psubscribe('sse:stream:*', 'sse:user:*');
+    sub.on('pmessage', (_pattern: string, channel: string, message: string) => {
+      try {
+        const { event, data } = JSON.parse(message) as { event: string; data: unknown };
+        if (channel.startsWith('sse:stream:')) {
+          this._localBroadcastToStream(channel.slice('sse:stream:'.length), event, data);
+        } else if (channel.startsWith('sse:user:')) {
+          this._localBroadcastToUser(channel.slice('sse:user:'.length), event, data);
+        }
+      } catch (err) {
+        logger.warn('[Redis SSE] Failed to handle pub/sub message:', err);
+      }
+    });
+
+    logger.info('[SSEService] Redis pub/sub subscription active.');
+  }
 
   addClient(clientId: string, res: Response, subscriptions: string[] = []): void {
     const client: SSEClient = {
@@ -26,9 +53,21 @@ class SSEService {
     });
   }
 
-  broadcast(event: string, data: any, filter?: (client: SSEClient) => boolean): void {
+  sendReconnectToAll(): void {
+    this.shuttingDown = true;
+    const message = 'event: reconnect\ndata: {}\n\n';
+    for (const client of this.clients.values()) {
+      try {
+        client.res.write(message);
+      } catch {
+        // ignore write errors during shutdown
+      }
+    }
+    logger.info(`[SSEService] Sent reconnect to ${this.clients.size} client(s).`);
+  }
+
+  broadcast(event: string, data: unknown, filter?: (client: SSEClient) => boolean): void {
     const message = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
-    
     for (const client of this.clients.values()) {
       if (!filter || filter(client)) {
         client.res.write(message);
@@ -36,14 +75,30 @@ class SSEService {
     }
   }
 
-  broadcastToStream(streamId: string, event: string, data: any): void {
-    this.broadcast(event, data, (client) => 
+  broadcastToStream(streamId: string, event: string, data: unknown): void {
+    if (isRedisAvailable()) {
+      getPublisher()?.publish(`sse:stream:${streamId}`, JSON.stringify({ event, data }));
+    } else {
+      this._localBroadcastToStream(streamId, event, data);
+    }
+  }
+
+  broadcastToUser(publicKey: string, event: string, data: unknown): void {
+    if (isRedisAvailable()) {
+      getPublisher()?.publish(`sse:user:${publicKey}`, JSON.stringify({ event, data }));
+    } else {
+      this._localBroadcastToUser(publicKey, event, data);
+    }
+  }
+
+  private _localBroadcastToStream(streamId: string, event: string, data: unknown): void {
+    this.broadcast(event, data, (client) =>
       client.subscriptions.has(streamId) || client.subscriptions.has('*')
     );
   }
 
-  broadcastToUser(publicKey: string, event: string, data: any): void {
-    this.broadcast(event, data, (client) => 
+  private _localBroadcastToUser(publicKey: string, event: string, data: unknown): void {
+    this.broadcast(event, data, (client) =>
       client.subscriptions.has(`user:${publicKey}`) || client.subscriptions.has('*')
     );
   }

--- a/backend/src/workers/soroban-event-worker.ts
+++ b/backend/src/workers/soroban-event-worker.ts
@@ -74,6 +74,7 @@ export class SorobanEventWorker {
 
   private isRunning = false;
   private pollTimer: NodeJS.Timeout | undefined;
+  private activeBatch: Promise<void> | null = null;
 
   constructor() {
     const rpcUrl =
@@ -117,6 +118,11 @@ export class SorobanEventWorker {
     logger.info('[SorobanWorker] Stopped.');
   }
 
+  /** Wait for the currently-running poll batch to finish (no-op if idle). */
+  async waitForDrain(): Promise<void> {
+    if (this.activeBatch) await this.activeBatch;
+  }
+
   // ─── Internal ──────────────────────────────────────────────────────────────
 
   private scheduleNext(): void {
@@ -125,11 +131,13 @@ export class SorobanEventWorker {
   }
 
   private async poll(): Promise<void> {
-    try {
-      await this.fetchAndProcessEvents();
-    } catch (err) {
+    this.activeBatch = this.fetchAndProcessEvents().catch((err) => {
       logger.error('[SorobanWorker] Unhandled error during poll:', err);
+    });
+    try {
+      await this.activeBatch;
     } finally {
+      this.activeBatch = null;
       this.scheduleNext();
     }
   }


### PR DESCRIPTION
## Summary

Resolves #228, resolves #229, resolves #230, resolves #231

---

## What was done

### #228 — Pagination for stream events list

* `GET /v1/streams/{id}/events` now returns `{ data, total, hasMore }` instead of a bare array
* Supports `limit` (default `50`, max `500`), `offset`, `cursor=<eventId>`, and `direction=asc|desc`
* Cursor-based pagination uses Prisma's native cursor API (skip-the-cursor, stable ordering by
  `createdAt`)
* Added `@@index([createdAt])` and `@@index([streamId, createdAt])` composite index to `StreamEvent` in
  `prisma/schema.prisma`
* Updated Swagger docs for the events endpoint

### #229 — Graceful shutdown with SSE connection draining

* On `SIGTERM` / `SIGINT`: sets a shutdown flag → sends `event: reconnect` to all connected SSE clients →
  stops accepting new SSE connections (`503`) → stops the HTTP server → waits up to **30 s** for the
  in-flight indexer batch → disconnects Redis → disconnects Prisma → exits `0` (`1` on timeout)
* `SorobanEventWorker.waitForDrain()` tracks the active batch promise and resolves when idle
* `sseService.isShuttingDown()` checked in the SSE subscribe handler

### #230 — Redis pub/sub for horizontal SSE scaling

* New `backend/src/lib/redis.ts`: initializes a publisher + subscriber pair using `ioredis`, with a
  `retryStrategy` and graceful fallback — if `REDIS_URL` is unset or Redis is unreachable, the service
  runs in single-instance in-process mode automatically
* `sseService.broadcastToStream` / `broadcastToUser`: when Redis is available, publishes to
  `sse:stream:{id}` / `sse:user:{key}`; otherwise falls back to local broadcast
* Each instance `PSUBSCRIBE`s to `sse:stream:*` and `sse:user:*` on startup and routes incoming messages
  to local SSE clients
* `REDIS_URL` added to `.env.example` with documentation
* `ioredis ^5.3.2` added to `package.json`

### #231 — Admin metrics endpoint

* New `backend/src/routes/adminRoutes.ts` mounted at `/v1/admin`
* `GET /v1/admin/metrics` — requires `Authorization: Bearer <ADMIN_SECRET>`; returns stream counts by
  status, events indexed in last **24 h**, SSE connection count, indexer last ledger + lag seconds, and
  server uptime
* `GET /health` updated to include `db`, `indexer.status`, and `indexer.lastLedger` fields; still returns
  `503` when DB is down
* `ADMIN_SECRET` added to `.env.example`
