### PR TITLE
feat: top-up modal, pause/resume tracker, activity timeline, admin metrics

### DIFF
--- a/backend/src/routes/v1/admin.routes.ts
+++ b/backend/src/routes/v1/admin.routes.ts
@@ -28,84 +28,133 @@ router.use(requireAdmin);
  *       200:
  *         description: Protocol health metrics
  */
+const ADMIN_METRICS_CACHE_KEY = 'admin:metrics';
+const ADMIN_METRICS_CACHE_TTL_SECONDS = 60;
+
+async function buildAdminMetrics() {
+  const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  const [
+    activeCount,
+    pausedCount,
+    totalCount,
+    cancelledCount,
+    completedCount,
+    eventsLast24h,
+    indexerState,
+    feeEvents,
+    feesLast24h,
+    withdrawnSums,
+  ] = await Promise.all([
+    prisma.stream.count({ where: { isActive: true } }),
+    prisma.stream.count({ where: { isPaused: true } }),
+    prisma.stream.count(),
+    prisma.stream.count({
+      where: { isActive: false, events: { some: { eventType: 'CANCELLED' } } },
+    }),
+    prisma.stream.count({
+      where: { isActive: false, events: { some: { eventType: 'COMPLETED' } } },
+    }),
+    prisma.streamEvent.count({ where: { createdAt: { gte: since24h } } }),
+    prisma.indexerState.findUnique({ where: { id: 'singleton' } }),
+    prisma.streamEvent.findMany({
+      where: { eventType: 'FEE_COLLECTED' },
+      select: { amount: true, metadata: true },
+    }),
+    prisma.streamEvent.findMany({
+      where: { eventType: 'FEE_COLLECTED', createdAt: { gte: since24h } },
+      select: { amount: true, metadata: true },
+    }),
+    prisma.stream.findMany({ select: { withdrawnAmount: true } }),
+  ]);
+
+  // Aggregate fees by token
+  const totalFeesCollectedByToken: Record<string, string> = {};
+  const feesLast24hByToken: Record<string, string> = {};
+
+  for (const event of feeEvents) {
+    const metadata = event.metadata ? JSON.parse(event.metadata) : {};
+    const token = metadata.token || 'unknown';
+    const amount = BigInt(event.amount || '0');
+    totalFeesCollectedByToken[token] = (
+      BigInt(totalFeesCollectedByToken[token] || '0') + amount
+    ).toString();
+  }
+
+  for (const event of feesLast24h) {
+    const metadata = event.metadata ? JSON.parse(event.metadata) : {};
+    const token = metadata.token || 'unknown';
+    const amount = BigInt(event.amount || '0');
+    feesLast24hByToken[token] = (
+      BigInt(feesLast24hByToken[token] || '0') + amount
+    ).toString();
+  }
+
+  // Sum total volume streamed (sum of withdrawn amounts) as BigInt to preserve i128 precision.
+  let totalVolumeStreamed = BigInt(0);
+  for (const row of withdrawnSums) {
+    totalVolumeStreamed += BigInt(row.withdrawnAmount || '0');
+  }
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const lagSeconds = indexerState
+    ? nowSec - Math.floor(indexerState.updatedAt.getTime() / 1000)
+    : null;
+
+  return {
+    // Snake_case summary requested by issue #426. Exposed at the top level so
+    // operators (and future dashboards) can read aggregate counts without
+    // walking the nested protocol-health tree below.
+    total_streams: totalCount,
+    active_streams: activeCount,
+    paused_streams: pausedCount,
+    completed_streams: completedCount,
+    cancelled_streams: cancelledCount,
+    total_volume_streamed: totalVolumeStreamed.toString(),
+
+    streams: {
+      active: activeCount,
+      paused: pausedCount,
+      total: totalCount,
+      byStatus: {
+        active: activeCount,
+        paused: pausedCount,
+        cancelled: cancelledCount,
+        completed: completedCount,
+      },
+    },
+    events: { last24h: eventsLast24h },
+    fees: {
+      totalFeesCollectedByToken,
+      feesLast24h: feesLast24hByToken,
+    },
+    sse: { activeConnections: sseService.getClientCount() },
+    cache: cache.getStats(),
+    indexer: {
+      lastLedger: indexerState?.lastLedger ?? 0,
+      lagSeconds,
+      lastUpdated: indexerState?.updatedAt ?? null,
+    },
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+  };
+}
+
 router.get('/metrics', async (_req: Request, res: Response) => {
   try {
-    const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
-
-    const [activeCount, totalCount, cancelledCount, completedCount, eventsLast24h, indexerState, feeEvents, feesLast24h] =
-      await Promise.all([
-        prisma.stream.count({ where: { isActive: true } }),
-        prisma.stream.count(),
-        prisma.stream.count({
-          where: { isActive: false, events: { some: { eventType: 'CANCELLED' } } },
-        }),
-        prisma.stream.count({
-          where: { isActive: false, events: { some: { eventType: 'COMPLETED' } } },
-        }),
-        prisma.streamEvent.count({ where: { createdAt: { gte: since24h } } }),
-        prisma.indexerState.findUnique({ where: { id: 'singleton' } }),
-        prisma.streamEvent.findMany({
-          where: { eventType: 'FEE_COLLECTED' },
-          select: { amount: true, metadata: true },
-        }),
-        prisma.streamEvent.findMany({
-          where: { eventType: 'FEE_COLLECTED', createdAt: { gte: since24h } },
-          select: { amount: true, metadata: true },
-        }),
-      ]);
-
-    // Aggregate fees by token
-    const totalFeesCollectedByToken: Record<string, string> = {};
-    const feesLast24hByToken: Record<string, string> = {};
-
-    for (const event of feeEvents) {
-      const metadata = event.metadata ? JSON.parse(event.metadata) : {};
-      const token = metadata.token || 'unknown';
-      const amount = BigInt(event.amount || '0');
-      totalFeesCollectedByToken[token] = (
-        BigInt(totalFeesCollectedByToken[token] || '0') + amount
-      ).toString();
+    const cached = cache.get<Awaited<ReturnType<typeof buildAdminMetrics>>>(
+      ADMIN_METRICS_CACHE_KEY,
+    );
+    if (cached) {
+      res.set('X-Cache', 'HIT');
+      res.json(cached);
+      return;
     }
 
-    for (const event of feesLast24h) {
-      const metadata = event.metadata ? JSON.parse(event.metadata) : {};
-      const token = metadata.token || 'unknown';
-      const amount = BigInt(event.amount || '0');
-      feesLast24hByToken[token] = (
-        BigInt(feesLast24hByToken[token] || '0') + amount
-      ).toString();
-    }
-
-    const nowSec = Math.floor(Date.now() / 1000);
-    const lagSeconds = indexerState
-      ? nowSec - Math.floor(indexerState.updatedAt.getTime() / 1000)
-      : null;
-
-    res.json({
-      streams: {
-        active: activeCount,
-        total: totalCount,
-        byStatus: {
-          active: activeCount,
-          cancelled: cancelledCount,
-          completed: completedCount,
-        },
-      },
-      events: { last24h: eventsLast24h },
-      fees: {
-        totalFeesCollectedByToken,
-        feesLast24h: feesLast24hByToken,
-      },
-      sse: { activeConnections: sseService.getClientCount() },
-      cache: cache.getStats(), // Added my cache metrics
-      indexer: {
-        lastLedger: indexerState?.lastLedger ?? 0,
-        lagSeconds,
-        lastUpdated: indexerState?.updatedAt ?? null,
-      },
-      uptime: process.uptime(),
-      timestamp: new Date().toISOString(),
-    });
+    const payload = await buildAdminMetrics();
+    cache.set(ADMIN_METRICS_CACHE_KEY, payload, ADMIN_METRICS_CACHE_TTL_SECONDS);
+    res.set('X-Cache', 'MISS');
+    res.json(payload);
   } catch (err) {
     logger.error('Error fetching admin metrics:', err);
     res.status(500).json({ error: 'Internal server error' });

--- a/backend/src/routes/v1/events.routes.ts
+++ b/backend/src/routes/v1/events.routes.ts
@@ -1,10 +1,134 @@
 import { Router } from 'express';
-import type { Request, Response } from 'express';
+import type { Request, Response, NextFunction } from 'express';
 import { subscribe } from '../../controllers/sse.controller.js';
 import { sseService } from '../../services/sse.service.js';
 import { requireAuth } from '../../middleware/auth.js';
+import { prisma } from '../../lib/prisma.js';
+import logger from '../../logger.js';
 
 const router = Router();
+
+const EVENT_TYPES = new Set([
+  'CREATED',
+  'TOPPED_UP',
+  'WITHDRAWN',
+  'CANCELLED',
+  'COMPLETED',
+  'PAUSED',
+  'RESUMED',
+  'FEE_COLLECTED',
+]);
+
+const MAX_EVENT_LIMIT = 200;
+const DEFAULT_EVENT_LIMIT = 50;
+
+/**
+ * @openapi
+ * /v1/events:
+ *   get:
+ *     tags: [Events]
+ *     summary: List stream events for a wallet (paginated, filterable)
+ *     description: |
+ *       Returns a reverse-chronological list of stream events where the wallet
+ *       was either the sender or recipient. Supports event-type filtering and
+ *       limit/offset pagination — used by the frontend activity timeline.
+ *     parameters:
+ *       - in: query
+ *         name: address
+ *         required: true
+ *         schema: { type: string }
+ *         description: Stellar public key (G...)
+ *       - in: query
+ *         name: type
+ *         required: false
+ *         schema: { type: string }
+ *         description: |
+ *           Comma-separated list of event types to include. Allowed values:
+ *           CREATED, TOPPED_UP, WITHDRAWN, CANCELLED, COMPLETED, PAUSED,
+ *           RESUMED, FEE_COLLECTED.
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         schema: { type: integer, default: 50, maximum: 200 }
+ *       - in: query
+ *         name: offset
+ *         required: false
+ *         schema: { type: integer, default: 0 }
+ *       - in: query
+ *         name: page
+ *         required: false
+ *         schema: { type: integer, default: 1 }
+ *         description: Optional 1-based page index. Ignored when offset is set.
+ *     responses:
+ *       200:
+ *         description: Paginated event list
+ */
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const address = typeof req.query.address === 'string' ? req.query.address.trim() : '';
+    if (!address) {
+      res.status(400).json({ error: 'address query parameter is required' });
+      return;
+    }
+
+    const rawType = typeof req.query.type === 'string' ? req.query.type : '';
+    const requested = rawType
+      .split(',')
+      .map((t) => t.trim().toUpperCase())
+      .filter(Boolean);
+    const types = requested.filter((t) => EVENT_TYPES.has(t));
+    if (requested.length > 0 && types.length === 0) {
+      res.status(400).json({ error: 'No valid event types in `type` filter' });
+      return;
+    }
+
+    const parsedLimit = Number.parseInt(String(req.query.limit ?? ''), 10);
+    const limit = Number.isFinite(parsedLimit) && parsedLimit > 0
+      ? Math.min(parsedLimit, MAX_EVENT_LIMIT)
+      : DEFAULT_EVENT_LIMIT;
+
+    const hasOffset = req.query.offset !== undefined;
+    const parsedOffset = Number.parseInt(String(req.query.offset ?? ''), 10);
+    const parsedPage = Number.parseInt(String(req.query.page ?? ''), 10);
+    const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+    const offset = hasOffset && Number.isFinite(parsedOffset) && parsedOffset >= 0
+      ? parsedOffset
+      : (page - 1) * limit;
+
+    const where: {
+      stream: { OR: Array<{ sender: string } | { recipient: string }> };
+      eventType?: { in: string[] };
+    } = {
+      stream: {
+        OR: [{ sender: address }, { recipient: address }],
+      },
+    };
+    if (types.length > 0) {
+      where.eventType = { in: types };
+    }
+
+    const [events, total] = await Promise.all([
+      prisma.streamEvent.findMany({
+        where,
+        orderBy: { timestamp: 'desc' },
+        skip: offset,
+        take: limit,
+      }),
+      prisma.streamEvent.count({ where }),
+    ]);
+
+    res.json({
+      events,
+      total,
+      limit,
+      offset,
+      hasMore: offset + events.length < total,
+    });
+  } catch (err) {
+    logger.error('GET /v1/events failed:', err);
+    next(err);
+  }
+});
 
 /**
  * @openapi

--- a/backend/tests/integration/admin-metrics.test.ts
+++ b/backend/tests/integration/admin-metrics.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Integration tests for GET /v1/admin/metrics.
+ *
+ * Mocks the Prisma client, SSE service, and Redis-backed cache so the
+ * endpoint can be exercised in CI without a database. Admin auth is
+ * bypassed by stubbing the middleware to a no-op.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+// vi.mock calls are hoisted, so any references must come from vi.hoisted().
+const mocks = vi.hoisted(() => {
+  return {
+    sseService: {
+      broadcastToStream: vi.fn(),
+      broadcastToUser: vi.fn(),
+      addClient: vi.fn(),
+      removeClient: vi.fn(),
+      getClientCount: vi.fn().mockReturnValue(7),
+      getActiveIpCount: vi.fn().mockReturnValue(2),
+      getPerIpPeakConnections: vi.fn().mockReturnValue(3),
+      getMaxConnections: vi.fn().mockReturnValue(10000),
+      checkCapacity: vi.fn().mockReturnValue({ allowed: true }),
+      isShuttingDown: vi.fn().mockReturnValue(false),
+      initRedisSubscription: vi.fn().mockResolvedValue(undefined),
+    },
+    cache: {
+      get: vi.fn().mockReturnValue(null),
+      set: vi.fn(),
+      del: vi.fn(),
+      getMetadata: vi.fn(),
+      getStats: vi.fn().mockReturnValue({
+        hits: 0,
+        misses: 0,
+        hitRate: 0,
+        itemCount: 0,
+      }),
+      cleanup: vi.fn(),
+    },
+    prisma: {
+      stream: {
+        count: vi.fn(),
+        findMany: vi.fn(),
+      },
+      streamEvent: {
+        count: vi.fn(),
+        findMany: vi.fn(),
+      },
+      indexerState: {
+        findUnique: vi.fn(),
+      },
+      $disconnect: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../../src/services/sse.service.js', () => ({
+  sseService: mocks.sseService,
+  SSEService: vi.fn(() => mocks.sseService),
+}));
+
+vi.mock('../../src/lib/redis.js', () => ({
+  cache: mocks.cache,
+  isRedisAvailable: vi.fn().mockReturnValue(false),
+  getPublisher: vi.fn().mockReturnValue(null),
+  getSubscriber: vi.fn().mockReturnValue(null),
+  connectRedis: vi.fn().mockResolvedValue(undefined),
+  disconnectRedis: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/lib/prisma.js', () => ({
+  default: mocks.prisma,
+  prisma: mocks.prisma,
+}));
+
+vi.mock('../../src/middleware/auth.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/middleware/auth.js')>(
+    '../../src/middleware/auth.js',
+  );
+  return {
+    ...actual,
+    requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
+    requireAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+  };
+});
+
+vi.mock('../../src/services/indexerService.js', () => ({
+  getIndexerStatus: vi.fn().mockResolvedValue({}),
+  resetIndexer: vi.fn().mockResolvedValue(undefined),
+  replayFromLedger: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ─── Import app after mocks are registered ────────────────────────────────────
+
+import app from '../../src/app.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function setupCounts({
+  total = 10,
+  active = 6,
+  paused = 1,
+  cancelled = 2,
+  completed = 1,
+}: Partial<Record<'total' | 'active' | 'paused' | 'cancelled' | 'completed', number>> = {}) {
+  // Order in admin.routes.ts: active -> paused -> total -> cancelled -> completed.
+  mocks.prisma.stream.count
+    .mockResolvedValueOnce(active)
+    .mockResolvedValueOnce(paused)
+    .mockResolvedValueOnce(total)
+    .mockResolvedValueOnce(cancelled)
+    .mockResolvedValueOnce(completed);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /v1/admin/metrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cache.get.mockReturnValue(null);
+    mocks.prisma.streamEvent.count.mockResolvedValue(0);
+    mocks.prisma.streamEvent.findMany.mockResolvedValue([]);
+    mocks.prisma.indexerState.findUnique.mockResolvedValue(null);
+    mocks.prisma.stream.findMany.mockResolvedValue([]);
+  });
+
+  it('returns the snake_case summary required by the public contract', async () => {
+    setupCounts({ total: 12, active: 7, paused: 2, cancelled: 2, completed: 1 });
+    mocks.prisma.stream.findMany.mockResolvedValue([
+      { withdrawnAmount: '500' },
+      { withdrawnAmount: '1500' },
+      { withdrawnAmount: '0' },
+    ]);
+
+    const res = await request(app).get('/v1/admin/metrics');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      total_streams: 12,
+      active_streams: 7,
+      paused_streams: 2,
+      completed_streams: 1,
+      cancelled_streams: 2,
+      total_volume_streamed: '2000',
+    });
+  });
+
+  it('preserves precision for very large i128 withdrawn sums', async () => {
+    setupCounts();
+    // Two values whose sum overflows JS safe-integer range — must round-trip
+    // as the exact string.
+    mocks.prisma.stream.findMany.mockResolvedValue([
+      { withdrawnAmount: '9007199254740993' },
+      { withdrawnAmount: '9007199254740993' },
+    ]);
+
+    const res = await request(app).get('/v1/admin/metrics');
+
+    expect(res.status).toBe(200);
+    expect(res.body.total_volume_streamed).toBe('18014398509481986');
+  });
+
+  it('caches the response for 60 seconds', async () => {
+    setupCounts({ total: 4, active: 4 });
+
+    const first = await request(app).get('/v1/admin/metrics');
+    expect(first.status).toBe(200);
+    expect(first.headers['x-cache']).toBe('MISS');
+
+    expect(mocks.cache.set).toHaveBeenCalledTimes(1);
+    expect(mocks.cache.set).toHaveBeenCalledWith(
+      'admin:metrics',
+      expect.objectContaining({ total_streams: 4 }),
+      60,
+    );
+  });
+
+  it('serves a cached response without re-querying the database', async () => {
+    const cachedPayload = {
+      total_streams: 99,
+      active_streams: 50,
+      paused_streams: 5,
+      completed_streams: 30,
+      cancelled_streams: 14,
+      total_volume_streamed: '123456789',
+    };
+    mocks.cache.get.mockReturnValueOnce(cachedPayload);
+
+    const res = await request(app).get('/v1/admin/metrics');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['x-cache']).toBe('HIT');
+    expect(res.body).toMatchObject(cachedPayload);
+    expect(mocks.prisma.stream.count).not.toHaveBeenCalled();
+    expect(mocks.prisma.stream.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/integration/events-list.test.ts
+++ b/backend/tests/integration/events-list.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Integration tests for GET /v1/events.
+ *
+ * Verifies the activity-page contract: address filter, event-type filter,
+ * pagination via limit/offset, and the shape returned to the frontend
+ * (events, total, hasMore).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    streamEvent: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+  sseService: {
+    broadcastToStream: vi.fn(),
+    broadcastToUser: vi.fn(),
+    addClient: vi.fn(),
+    removeClient: vi.fn(),
+    getClientCount: vi.fn().mockReturnValue(0),
+    getActiveIpCount: vi.fn().mockReturnValue(0),
+    getPerIpPeakConnections: vi.fn().mockReturnValue(0),
+    getMaxConnections: vi.fn().mockReturnValue(10000),
+    checkCapacity: vi.fn().mockReturnValue({ allowed: true }),
+    isShuttingDown: vi.fn().mockReturnValue(false),
+    initRedisSubscription: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../src/lib/prisma.js', () => ({
+  default: mocks.prisma,
+  prisma: mocks.prisma,
+}));
+
+vi.mock('../../src/services/sse.service.js', () => ({
+  sseService: mocks.sseService,
+  SSEService: vi.fn(() => mocks.sseService),
+}));
+
+vi.mock('../../src/lib/redis.js', () => ({
+  cache: {
+    get: vi.fn().mockReturnValue(null),
+    set: vi.fn(),
+    del: vi.fn(),
+    getMetadata: vi.fn(),
+    getStats: vi.fn().mockReturnValue({ hits: 0, misses: 0, hitRate: 0, itemCount: 0 }),
+    cleanup: vi.fn(),
+  },
+  isRedisAvailable: vi.fn().mockReturnValue(false),
+  getPublisher: vi.fn().mockReturnValue(null),
+  getSubscriber: vi.fn().mockReturnValue(null),
+  connectRedis: vi.fn().mockResolvedValue(undefined),
+  disconnectRedis: vi.fn().mockResolvedValue(undefined),
+}));
+
+import app from '../../src/app.js';
+
+const ADDR = 'GABC123XYZ456DEF789GHI012JKL345MNO678PQR901STU234VWX567YZA';
+
+function makeEvent(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'evt-1',
+    streamId: 1,
+    eventType: 'CREATED',
+    amount: '1000',
+    transactionHash: 'tx-hash',
+    ledgerSequence: 1,
+    timestamp: 1700000000,
+    metadata: null,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('GET /v1/events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects requests missing the `address` query parameter', async () => {
+    const res = await request(app).get('/v1/events');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/address/i);
+    expect(mocks.prisma.streamEvent.findMany).not.toHaveBeenCalled();
+  });
+
+  it('returns the paged event list for the wallet', async () => {
+    const events = [makeEvent({ id: 'a', timestamp: 3 }), makeEvent({ id: 'b', timestamp: 2 })];
+    mocks.prisma.streamEvent.findMany.mockResolvedValueOnce(events);
+    mocks.prisma.streamEvent.count.mockResolvedValueOnce(5);
+
+    const res = await request(app).get(`/v1/events?address=${ADDR}&limit=2`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.events).toHaveLength(2);
+    expect(res.body).toMatchObject({ total: 5, limit: 2, offset: 0, hasMore: true });
+
+    const callArgs = mocks.prisma.streamEvent.findMany.mock.calls[0][0];
+    expect(callArgs.where.stream.OR).toEqual([{ sender: ADDR }, { recipient: ADDR }]);
+    expect(callArgs.orderBy).toEqual({ timestamp: 'desc' });
+    expect(callArgs.take).toBe(2);
+    expect(callArgs.skip).toBe(0);
+  });
+
+  it('forwards a comma-separated type filter to Prisma', async () => {
+    mocks.prisma.streamEvent.findMany.mockResolvedValueOnce([]);
+    mocks.prisma.streamEvent.count.mockResolvedValueOnce(0);
+
+    const res = await request(app).get(
+      `/v1/events?address=${ADDR}&type=PAUSED,RESUMED`,
+    );
+    expect(res.status).toBe(200);
+
+    const where = mocks.prisma.streamEvent.findMany.mock.calls[0][0].where;
+    expect(where.eventType).toEqual({ in: ['PAUSED', 'RESUMED'] });
+  });
+
+  it('rejects a type filter when no values are valid', async () => {
+    const res = await request(app).get(`/v1/events?address=${ADDR}&type=BOGUS`);
+    expect(res.status).toBe(400);
+    expect(mocks.prisma.streamEvent.findMany).not.toHaveBeenCalled();
+  });
+
+  it('supports page-based pagination as a fallback for offset', async () => {
+    mocks.prisma.streamEvent.findMany.mockResolvedValueOnce([]);
+    mocks.prisma.streamEvent.count.mockResolvedValueOnce(100);
+
+    const res = await request(app).get(
+      `/v1/events?address=${ADDR}&limit=10&page=4`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.offset).toBe(30);
+    expect(mocks.prisma.streamEvent.findMany.mock.calls[0][0].skip).toBe(30);
+  });
+});

--- a/frontend/src/app/activity/page.tsx
+++ b/frontend/src/app/activity/page.tsx
@@ -7,6 +7,11 @@ import { BackendStreamEvent } from "@/lib/api-types";
 import { Button } from "@/components/ui/Button";
 import { Loader2 } from "lucide-react";
 
+const PAGE_SIZE = 10;
+const API_BASE_URL = (
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001"
+).replace(/\/+$/, "");
+
 const TABS = [
   { id: "ALL", label: "All" },
   { id: "CREATED", label: "Created" },
@@ -20,7 +25,7 @@ export default function ActivityPage() {
   const { session, status } = useWallet();
   const [events, setEvents] = useState<BackendStreamEvent[]>([]);
   const [activeTab, setActiveTab] = useState("ALL");
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
 
@@ -30,23 +35,35 @@ export default function ActivityPage() {
       setLoading(true);
 
       try {
-        // Adjusting filter logic for the 'PAUSED' tab which includes RESUMED
+        // The 'PAUSED' tab is a UX shortcut that surfaces both PAUSED and RESUMED.
         const typeFilter = tab === "PAUSED" ? "PAUSED,RESUMED" : tab;
-        const query = tab === "ALL" ? "" : `&type=${typeFilter}`;
+        const typeQuery = tab === "ALL" ? "" : `&type=${encodeURIComponent(typeFilter)}`;
+        const url =
+          `${API_BASE_URL}/v1/events?address=${encodeURIComponent(session.publicKey)}` +
+          `&page=${pageNum}&limit=${PAGE_SIZE}${typeQuery}`;
 
-        const response = await fetch(
-          `/v1/events?address=${session.publicKey}&page=${pageNum}&limit=10${query}`,
-        );
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch activity (${response.status})`);
+        }
         const data = await response.json();
 
-        if (data.events) {
-          setEvents((prev) =>
-            append ? [...prev, ...data.events] : data.events,
-          );
-          setHasMore(data.events.length === 10);
+        const next: BackendStreamEvent[] = Array.isArray(data?.events)
+          ? data.events
+          : [];
+
+        setEvents((prev) => (append ? [...prev, ...next] : next));
+
+        // Prefer the server-provided hasMore; fall back to a length heuristic.
+        if (typeof data?.hasMore === "boolean") {
+          setHasMore(data.hasMore);
+        } else {
+          setHasMore(next.length === PAGE_SIZE);
         }
       } catch (error) {
         console.error("Failed to fetch activity:", error);
+        if (!append) setEvents([]);
+        setHasMore(false);
       } finally {
         setLoading(false);
       }
@@ -55,10 +72,9 @@ export default function ActivityPage() {
   );
 
   useEffect(() => {
-    if (status === "connected" && !loading) {
-      setPage(1);
-      fetchActivity(1, activeTab, false);
-    }
+    if (status !== "connected") return;
+    setPage(1);
+    fetchActivity(1, activeTab, false);
   }, [activeTab, status, fetchActivity]);
 
   const loadMore = () => {

--- a/frontend/src/app/streams/[id]/page.tsx
+++ b/frontend/src/app/streams/[id]/page.tsx
@@ -4,6 +4,9 @@ import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import LiveCounter from "@/components/Livecounter";
 import ProgressBar from "@/components/Progressbar";
+import TransactionTracker, {
+  type TransactionStatus,
+} from "@/components/TransactionTracker";
 import { Button } from "@/components/ui/Button";
 import toast from "react-hot-toast";
 import { useWallet } from "@/context/wallet-context";
@@ -16,7 +19,6 @@ import {
   resumeStream,
   toSorobanErrorMessage,
 } from "@/lib/soroban";
-import type { WalletSession } from "@/lib/wallet";
 
 interface StreamDetail {
   id: string;
@@ -49,6 +51,14 @@ export default function StreamDetailsPage() {
   const [resuming, setResuming] = useState(false);
   const [topUpAmount, setTopUpAmount] = useState("");
   const [showTopUp, setShowTopUp] = useState(false);
+  const [pauseResumeStatus, setPauseResumeStatus] =
+    useState<TransactionStatus>("idle");
+  const [pauseResumeTxHash, setPauseResumeTxHash] = useState<string | undefined>(
+    undefined,
+  );
+  const [pauseResumeError, setPauseResumeError] = useState<string | undefined>(
+    undefined,
+  );
 
   // SSE integration for real-time stream updates
   const { events: streamEvents, connected, reconnecting } = useStreamEvents({
@@ -174,6 +184,19 @@ export default function StreamDetailsPage() {
     }
   };
 
+  const refetchStream = async () => {
+    try {
+      const baseUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+      const response = await fetch(`${baseUrl}/v1/streams/${streamId}`);
+      if (response.ok) {
+        const data = await response.json();
+        setStream(data);
+      }
+    } catch (err) {
+      console.error("Failed to refresh stream:", err);
+    }
+  };
+
   const handlePause = async () => {
     if (!session) {
       toast.error("Please connect your wallet first");
@@ -181,13 +204,23 @@ export default function StreamDetailsPage() {
     }
 
     setPausing(true);
+    setPauseResumeError(undefined);
+    setPauseResumeTxHash(undefined);
+    setPauseResumeStatus("signing");
     try {
-      await pauseStream(session, { streamId: BigInt(streamId) });
-      toast.success("Stream paused successfully!");
-      // Refresh stream data
-      window.location.reload();
+      const result = await pauseStream(session, {
+        streamId: BigInt(streamId),
+      });
+      setPauseResumeTxHash(result.txHash);
+      setPauseResumeStatus("submitted");
+      toast.success("Stream pause submitted!");
+      await refetchStream();
+      setPauseResumeStatus("confirmed");
     } catch (err) {
-      toast.error(toSorobanErrorMessage(err));
+      const message = toSorobanErrorMessage(err);
+      setPauseResumeError(message);
+      setPauseResumeStatus("failed");
+      toast.error(message);
     } finally {
       setPausing(false);
     }
@@ -200,13 +233,23 @@ export default function StreamDetailsPage() {
     }
 
     setResuming(true);
+    setPauseResumeError(undefined);
+    setPauseResumeTxHash(undefined);
+    setPauseResumeStatus("signing");
     try {
-      await resumeStream(session, { streamId: BigInt(streamId) });
-      toast.success("Stream resumed successfully!");
-      // Refresh stream data
-      window.location.reload();
+      const result = await resumeStream(session, {
+        streamId: BigInt(streamId),
+      });
+      setPauseResumeTxHash(result.txHash);
+      setPauseResumeStatus("submitted");
+      toast.success("Stream resume submitted!");
+      await refetchStream();
+      setPauseResumeStatus("confirmed");
     } catch (err) {
-      toast.error(toSorobanErrorMessage(err));
+      const message = toSorobanErrorMessage(err);
+      setPauseResumeError(message);
+      setPauseResumeStatus("failed");
+      toast.error(message);
     } finally {
       setResuming(false);
     }
@@ -405,6 +448,23 @@ export default function StreamDetailsPage() {
                 }}
               />
               <Button onClick={handleTopUp}>Add Funds</Button>
+            </div>
+          )}
+
+          {pauseResumeStatus !== "idle" && (
+            <div style={{ marginTop: "1rem" }}>
+              <TransactionTracker
+                status={pauseResumeStatus}
+                txHash={pauseResumeTxHash}
+                error={pauseResumeError}
+                onRetry={
+                  pauseResumeStatus === "failed"
+                    ? stream.isPaused
+                      ? handleResume
+                      : handlePause
+                    : undefined
+                }
+              />
             </div>
           )}
         </div>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -6,6 +6,12 @@ import { BackendStreamEvent } from '@/lib/api-types';
 import { downloadCSV } from '@/utils/csvExport';
 import toast from 'react-hot-toast';
 import { fromStroops } from '@/utils/amount';
+import { TopUpModal } from './stream-creation/TopUpModal';
+import {
+    topUpStream as sorobanTopUp,
+    toBaseUnits,
+    toSorobanErrorMessage,
+} from '@/lib/soroban';
 
 interface StreamData extends Record<string, unknown> {
     id: string;
@@ -31,6 +37,7 @@ const Dashboard: React.FC = () => {
     const [activeTab, setActiveTab] = React.useState<'streams' | 'activity'>('streams');
     const [events, setEvents] = React.useState<BackendStreamEvent[]>([]);
     const [isLoadingEvents, setIsLoadingEvents] = React.useState(false);
+    const [topUpStream, setTopUpStream] = React.useState<StreamData | null>(null);
 
     React.useEffect(() => {
         if (activeTab === 'activity' && session?.publicKey) {
@@ -57,12 +64,29 @@ const Dashboard: React.FC = () => {
         toast.success('CSV exported successfully!');
     };
 
-    const handleTopUp = (streamId: string) => {
-        const amount = prompt(`Enter amount to add to stream ${streamId}:`);
-        if (amount && parseFloat(amount) > 0) {
-            console.log(`Adding ${amount} funds to stream ${streamId}`);
-            // TODO: Integrate with Soroban contract's top_up_stream function
-            toast.success(`Successfully added ${amount} to stream ${streamId}`);
+    const handleTopUp = (stream: StreamData) => {
+        if (!session) {
+            toast.error('Please connect your wallet first');
+            return;
+        }
+        setTopUpStream(stream);
+    };
+
+    const handleTopUpConfirm = async (streamId: string, amountStr: string) => {
+        if (!session) {
+            throw new Error('Wallet not connected');
+        }
+        const toastId = toast.loading('Topping up stream…');
+        try {
+            await sorobanTopUp(session, {
+                streamId: BigInt(streamId.replace(/\D/g, '') || '0'),
+                amount: toBaseUnits(amountStr),
+            });
+            toast.success('Stream topped up successfully!', { id: toastId });
+            setTopUpStream(null);
+        } catch (err) {
+            toast.error(toSorobanErrorMessage(err), { id: toastId });
+            throw err;
         }
     };
 
@@ -126,7 +150,7 @@ const Dashboard: React.FC = () => {
                                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                                         {stream.status === 'Active' && (
                                             <button
-                                                onClick={() => handleTopUp(stream.id)}
+                                                onClick={() => handleTopUp(stream)}
                                                 className="text-green-600 hover:text-green-900 dark:text-green-400 dark:hover:text-green-300 bg-green-50 dark:bg-green-900/20 px-3 py-1 rounded-md transition-colors font-semibold"
                                             >
                                                 Add Funds
@@ -154,6 +178,16 @@ const Dashboard: React.FC = () => {
                         <ActivityHistory events={events} isLoading={isLoadingEvents} />
                     )}
                 </>
+            )}
+
+            {topUpStream && (
+                <TopUpModal
+                    streamId={topUpStream.id}
+                    token={topUpStream.token}
+                    currentDeposited={topUpStream.deposited}
+                    onConfirm={handleTopUpConfirm}
+                    onClose={() => setTopUpStream(null)}
+                />
             )}
         </div>
     );

--- a/frontend/src/components/dashboard/ActivityHistory.tsx
+++ b/frontend/src/components/dashboard/ActivityHistory.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import Link from "next/link";
 import { BackendStreamEvent } from "@/lib/api-types";
 import { fromStroops } from "@/utils/amount";
 import TransactionTracker from "@/components/TransactionTracker";
@@ -47,27 +48,42 @@ export const ActivityHistory: React.FC<ActivityHistoryProps> = ({
     document.body.removeChild(link);
   };
 
-  const formatEventMessage = (event: BackendStreamEvent) => {
+  const renderEventMessage = (event: BackendStreamEvent): React.ReactNode => {
     const amount = event.amount ? fromStroops(BigInt(event.amount), 7) : "0";
-    const streamId = event.streamId;
+    const link = (
+      <Link
+        href={`/streams/${event.streamId}`}
+        className="text-accent hover:underline font-mono"
+      >
+        #{event.streamId}
+      </Link>
+    );
 
     switch (event.eventType) {
       case "CREATED":
-        return `New stream created (#${streamId})`;
+        return <>New stream created ({link})</>;
       case "TOPPED_UP":
-        return `Topped up Stream #${streamId} with ${amount} tokens`;
+        return (
+          <>
+            Topped up Stream {link} with {amount} tokens
+          </>
+        );
       case "WITHDRAWN":
-        return `Withdrew ${amount} tokens from Stream #${streamId}`;
+        return (
+          <>
+            Withdrew {amount} tokens from Stream {link}
+          </>
+        );
       case "CANCELLED":
-        return `Stream #${streamId} was cancelled`;
+        return <>Stream {link} was cancelled</>;
       case "COMPLETED":
-        return `Stream #${streamId} was completed`;
+        return <>Stream {link} was completed</>;
       case "PAUSED":
-        return `Stream #${streamId} was paused`;
+        return <>Stream {link} was paused</>;
       case "RESUMED":
-        return `Stream #${streamId} was resumed`;
+        return <>Stream {link} was resumed</>;
       default:
-        return `Event on Stream #${streamId}`;
+        return <>Event on Stream {link}</>;
     }
   };
 
@@ -116,7 +132,7 @@ export const ActivityHistory: React.FC<ActivityHistoryProps> = ({
               <div className="flex flex-col sm:flex-row justify-between items-start mb-2 gap-2">
                 <div>
                   <p className="text-white font-medium text-sm sm:text-base">
-                    {formatEventMessage(event)}
+                    {renderEventMessage(event)}
                   </p>
                   <time className="text-xs text-slate-400 flex items-center gap-1 mt-1">
                     {new Date(event.timestamp * 1000).toLocaleString()}


### PR DESCRIPTION
## Summary

Bundles four assigned issues that all touch overlapping pieces (stream actions, the activity feed, and admin observability) into a single PR so the diff stays coherent.

- **#355 — Replace prompt()/alert() in handleTopUp with proper TopUpModal**
  - `frontend/src/components/Dashboard.tsx`: removed the legacy `prompt()` flow and wired the row's "Add Funds" button to the existing `TopUpModal`, which calls `sorobanTopUp` via Freighter (`toBaseUnits` for amount conversion). Errors surface via `toSorobanErrorMessage`.

- **#356 — Add pause and resume buttons to stream detail page**
  - `frontend/src/app/streams/[id]/page.tsx`: pause and resume now drive a `TransactionTracker` (`signing → submitted → confirmed`/`failed`) instead of `window.location.reload()`. Failure state surfaces a retry that re-issues the correct action based on the current paused flag, and the page refetches the stream record after submission so SSE/state recover without a hard reload.

- **#424 — Build activity page with full event history**
  - Frontend: `frontend/src/app/activity/page.tsx` now hits the configured `NEXT_PUBLIC_API_URL`, drops the `!loading` gate that was suppressing the initial fetch, prefers the server-provided `hasMore`, and resets to an empty list on error. `frontend/src/components/dashboard/ActivityHistory.tsx` renders each timeline entry's stream id as a `<Link>` to the detail page so the audit log is navigable. The CSV export, the empty state, and the load-more pagination already existed and are kept intact.
  - Backend: new `GET /v1/events?address=&type=&limit=&offset=&page=` route in `backend/src/routes/v1/events.routes.ts` returns `{ events, total, limit, offset, hasMore }`. Type filter accepts a comma list; invalid filters 400. Pagination supports both `offset` (preferred) and `page` (1-based, falls back to `offset = (page - 1) * limit`). Capped at 200/page.

- **#426 — Add stream metrics endpoint**
  - `backend/src/routes/v1/admin.routes.ts`: kept the existing nested protocol-health response and added the snake_case summary the issue contract calls for (`total_streams`, `active_streams`, `paused_streams`, `completed_streams`, `cancelled_streams`, `total_volume_streamed`). `total_volume_streamed` sums `withdrawnAmount` as `BigInt` so i128 precision survives the JSON boundary. The handler is now wrapped in a 60-second `MemoryCache` (existing `cache` from `lib/redis.ts`) and emits `X-Cache: HIT/MISS` for visibility.

- **Tests**
  - `backend/tests/integration/admin-metrics.test.ts`: covers the response shape, large-i128 precision (sum of two values past `Number.MAX_SAFE_INTEGER`), the cache miss → set, and a cache hit that bypasses Prisma entirely.
  - `backend/tests/integration/events-list.test.ts`: covers the missing-address 400, the paged shape, the comma-separated type filter, the all-invalid type filter, and `page` → `offset` fallback.

closes #355
closes #356
closes #424
closes #426

## Test plan

- [x] `vitest run tests/integration/admin-metrics.test.ts` — 4/4 pass
- [x] `vitest run tests/integration/events-list.test.ts` — 5/5 pass
- [x] `tsc --noEmit` clean for the touched files (existing `dashboard-view.tsx` / `vitest.config.ts` errors are pre-existing on `main`)
- [x] `lint-staged` ran via the pre-commit hook
- [ ] Manual smoke: dashboard "Add Funds" → modal → Freighter → balance refresh
- [ ] Manual smoke: stream detail Pause → tracker progresses signing → submitted → confirmed
- [ ] Manual smoke: `/activity` lists events, type filter narrows, "Load more" appends, stream id link navigates to `/streams/[id]`
- [ ] Manual smoke: `GET /v1/admin/metrics` returns snake_case summary; second call within 60s returns `X-Cache: HIT`

## Notes

- I left the existing `/v1/admin/metrics` nested fields (`streams`, `events`, `fees`, `sse`, `cache`, `indexer`, `uptime`) in place so the operator console keeps working alongside the new top-level summary.
- `frontend/src/components/Dashboard.tsx` is currently unreferenced from any route, but #355 explicitly named the file, so its handler is fixed regardless.