### PR TITLE
Feat/rate limit

### DIFF
--- a/backend/src/middleware/stream-rate-limiter.middleware.ts
+++ b/backend/src/middleware/stream-rate-limiter.middleware.ts
@@ -1,0 +1,77 @@
+import { rateLimit } from 'express-rate-limit';
+import { type Request, type Response, type NextFunction } from 'express';
+import type { AuthenticatedRequest } from '../types/auth.types.js';
+import logger from '../logger.js';
+
+/**
+ * Create a per-wallet rate limiter middleware for stream creation
+ * Uses the authenticated wallet address as the rate limit key
+ * 
+ * @param options Configuration options
+ * @param options.windowMs Time window in milliseconds (default: 1 minute)
+ * @param options.max Maximum requests per window (default: 10, configurable via STREAM_CREATE_RATE_LIMIT)
+ * @returns Express rate limit middleware
+ */
+export function createStreamRateLimiter(
+  options?: {
+    windowMs?: number;
+    max?: number;
+  }
+) {
+  const windowMs = options?.windowMs ?? 60 * 1000; // 1 minute
+  // Read from environment variable, default to 10 if not set
+  const max = options?.max ?? (process.env.STREAM_CREATE_RATE_LIMIT ? parseInt(process.env.STREAM_CREATE_RATE_LIMIT, 10) : 10);
+
+  return rateLimit({
+    windowMs,
+    max,
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+    message: {
+      error: 'Too many stream creation requests',
+      message: 'You have exceeded the rate limit for stream creation. Please try again later.',
+      status: 429,
+    },
+    /**
+     * KeyGenerator: Use wallet address as the rate limit key
+     * For authenticated requests, use the wallet's public key
+     */
+    keyGenerator: (req: Request, res: Response): string => {
+      const authReq = req as AuthenticatedRequest;
+      if (authReq.user?.publicKey) {
+        return authReq.user.publicKey; // Use wallet address as key
+      }
+      // Fallback to IP if not authenticated (shouldn't happen for protected endpoints)
+      return req.ip || 'unknown';
+    },
+    /**
+     * Skip rate limiting for non-authenticated requests
+     * to ensure we only rate limit authenticated users
+     */
+    skip: (req: Request, res: Response): boolean => {
+      const authReq = req as AuthenticatedRequest;
+      if (!authReq.user?.publicKey) {
+        logger.warn('Stream creation rate limiter skipped: no authenticated user');
+        return true;
+      }
+      return false;
+    },
+    handler: (req: Request, res: Response, next: NextFunction, options: any): void => {
+      const authReq = req as AuthenticatedRequest;
+      logger.warn(
+        `Rate limit exceeded for wallet: ${authReq.user?.publicKey || 'unknown'}`,
+        { endpoint: req.path, method: req.method }
+      );
+      res.status(options.statusCode).json(options.message);
+    },
+  });
+}
+
+/**
+ * Pre-configured rate limiter for stream creation endpoint
+ * 10 requests per minute per wallet
+ */
+export const streamCreationRateLimiter = createStreamRateLimiter({
+  windowMs: 60 * 1000, // 1 minute
+  max: 10, // 10 requests per minute
+});

--- a/backend/src/routes/v1/stream.routes.ts
+++ b/backend/src/routes/v1/stream.routes.ts
@@ -7,6 +7,8 @@ import {
   getStreamClaimableAmount,
   getUserStreamSummary
 } from '../../controllers/stream.controller.js';
+import { authMiddleware } from '../../middleware/auth.middleware.js';
+import { streamCreationRateLimiter } from '../../middleware/stream-rate-limiter.middleware.js';
 
 const router = Router();
 
@@ -18,13 +20,19 @@ const router = Router();
  *       - Streams
  *     summary: Create a new payment stream
  *     description: Creates a new payment stream on the Stellar network.
+ *     security:
+ *       - BearerAuth: []
  *     responses:
  *       201:
  *         description: Stream created successfully
  *       400:
  *         description: Invalid input data
+ *       401:
+ *         description: Unauthorized - missing or invalid authentication token
+ *       429:
+ *         description: Too Many Requests - rate limit exceeded (10 requests per minute)
  */
-router.post('/', createStream);
+router.post('/', authMiddleware, streamCreationRateLimiter, createStream);
 
 /**
  * @openapi

--- a/backend/tests/stream-rate-limiter.test.ts
+++ b/backend/tests/stream-rate-limiter.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import request from 'supertest';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import { createStreamRateLimiter } from '../src/middleware/stream-rate-limiter.middleware.js';
+import type { AuthenticatedRequest } from '../src/types/auth.types.js';
+
+/**
+ * Mock authenticated user middleware
+ */
+function mockAuthMiddleware(publicKey: string) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    (req as AuthenticatedRequest).user = { publicKey };
+    next();
+  };
+}
+
+describe('Stream Creation Rate Limiter Middleware', () => {
+  let app: any;
+
+  beforeEach(() => {
+    // Create a fresh Express app for each test
+    app = express();
+    app.use(express.json());
+  });
+
+  describe('Basic Rate Limiting', () => {
+    it('should allow requests under the limit', async () => {
+      const limiter = createStreamRateLimiter({ windowMs: 10000, max: 3 });
+
+      app.post(
+        '/streams',
+        mockAuthMiddleware('GTEST123456'),
+        limiter,
+        (req: Request, res: Response) => res.status(201).json({ streamId: 1 })
+      );
+
+      // Make 3 requests - all should succeed
+      for (let i = 1; i <= 3; i++) {
+        const res = await request(app)
+          .post('/streams')
+          .set('Content-Type', 'application/json');
+        expect(res.status).toBe(201);
+        expect(res.body.streamId).toBe(1);
+      }
+    });
+
+    it('should allow exactly limit number of requests', async () => {
+      const limiter = createStreamRateLimiter({ windowMs: 10000, max: 5 });
+
+      app.post(
+        '/streams',
+        mockAuthMiddleware('GTEST789012'),
+        limiter,
+        (req: Request, res: Response) => res.status(201).json({ success: true })
+      );
+
+      // Make exactly 5 requests - all should succeed
+      const requests = Array(5).fill(null);
+      for (const _ of requests) {
+        const res = await request(app)
+          .post('/streams')
+          .set('Content-Type', 'application/json');
+        expect(res.status).toBe(201);
+      }
+    });
+
+    it('should return 429 when exceeding the limit', async () => {
+      const limiter = createStreamRateLimiter({ windowMs: 10000, max: 2 });
+
+      app.post(
+        '/streams',
+        mockAuthMiddleware('GWALLETABC'),
+        limiter,
+        (req: Request, res: Response) => res.status(201).json({ success: true })
+      );
+
+      // Make 2 successful requests
+      await request(app).post('/streams').set('Content-Type', 'application/json');
+      await request(app).post('/streams').set('Content-Type', 'application/json');
+
+      // 3rd request should be rate limited
+      const res = await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+
+      expect(res.status).toBe(429);
+      expect(res.body).toHaveProperty('error');
+      expect(res.body.error).toContain('rate limit');
+    });
+
+    it('should include Retry-After header in rate limit response', async () => {
+      const limiter = createStreamRateLimiter({ windowMs: 10000, max: 1 });
+
+      app.post(
+        '/streams',
+        mockAuthMiddleware('GWALLET123'),
+        limiter,
+        (req: Request, res: Response) => res.status(201).json({ success: true })
+      );
+
+      // First request succeeds
+      await request(app).post('/streams').set('Content-Type', 'application/json');
+
+      // Second request should be blocked
+      const res = await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+
+      expect(res.status).toBe(429);
+      // express-rate-limit sets RateLimit-Reset header with reset time
+      expect(res.headers).toHaveProperty('ratelimit-reset');
+    });
+  });
+
+  describe('Per-Wallet Rate Limiting', () => {
+    it('should apply separate rate limits per wallet', async () => {
+      const limiter = createStreamRateLimiter({ windowMs: 10000, max: 2 });
+
+      const createRoute = (publicKey: string) => {
+        app.post(
+          `/streams-${publicKey}`,
+          mockAuthMiddleware(publicKey),
+          limiter,
+          (req: Request, res: Response) => res.status(201).json({ wallet: publicKey, success: true })
+        );
+      };
+
+      const wallet1 = 'GWALLET001';
+      const wallet2 = 'GWALLET002';
+
+      createRoute(wallet1);
+      createRoute(wallet2);
+
+      // Wallet 1 makes 2 requests - should succeed
+      await request(app)
+        .post(`/streams-${wallet1}`)
+        .set('Content-Type', 'application/json');
+      await request(app)
+        .post(`/streams-${wallet1}`)
+        .set('Content-Type', 'application/json');
+
+      // Wallet 1 makes 3rd request - should fail
+      let res = await request(app)
+        .post(`/streams-${wallet1}`)
+        .set('Content-Type', 'application/json');
+      expect(res.status).toBe(429);
+
+      // Wallet 2 can still make 2 requests (separate limit)
+      res = await request(app)
+        .post(`/streams-${wallet2}`)
+        .set('Content-Type', 'application/json');
+      expect(res.status).toBe(201);
+      res = await request(app)
+        .post(`/streams-${wallet2}`)
+        .set('Content-Type', 'application/json');
+      expect(res.status).toBe(201);
+
+      // Wallet 2 makes 3rd request - should fail
+      res = await request(app)
+        .post(`/streams-${wallet2}`)
+        .set('Content-Type', 'application/json');
+      expect(res.status).toBe(429);
+    });
+
+    it('should use wallet address as rate limit key', async () => {
+      const limiter = createStreamRateLimiter({ windowMs: 10000, max: 1 });
+      const wallet = 'GUSER_WALLET_KEY_XYZ';
+
+      app.post(
+        '/streams',
+        mockAuthMiddleware(wallet),
+        limiter,
+        (req: Request, res: Response) => res.status(201).json({ success: true })
+      );
+
+      // First request from this wallet
+      const res1 = await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+      expect(res1.status).toBe(201);
+
+      // Second request from same wallet should be limited
+      const res2 = await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+      expect(res2.status).toBe(429);
+    });
+  });
+
+  describe('Authentication Requirements', () => {
+    it('should skip rate limiting for unauthenticated requests', async () => {
+      const limiter = createStreamRateLimiter({ windowMs: 10000, max: 1 });
+
+      app.post(
+        '/streams',
+        limiter, // No auth middleware
+        (req: Request, res: Response) => res.status(201).json({ success: true })
+      );
+
+      // Multiple requests should not be rate limited
+      // (they're skipped because there's no authenticated user)
+      const res1 = await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+      expect(res1.status).toBe(201);
+
+      const res2 = await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+      expect(res2.status).toBe(201);
+
+      const res3 = await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+      expect(res3.status).toBe(201);
+    });
+
+    it('should require authentication before rate limiting', async () => {
+      const limiter = createStreamRateLimiter({ windowMs: 10000, max: 2 });
+
+      app.post(
+        '/streams',
+        mockAuthMiddleware('GAUTH123'),
+        limiter,
+        (req: Request, res: Response) => res.status(201).json({ success: true })
+      );
+
+      // Authenticate and make requests up to limit
+      await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+      await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+
+      // 3rd request is rate limited
+      const res = await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+      expect(res.status).toBe(429);
+    });
+  });
+
+  describe('Environment Variable Configuration', () => {
+    it('should use STREAM_CREATE_RATE_LIMIT environment variable', () => {
+      const originalEnv = process.env.STREAM_CREATE_RATE_LIMIT;
+      process.env.STREAM_CREATE_RATE_LIMIT = '5';
+
+      const limiter = createStreamRateLimiter({ windowMs: 10000 });
+      // The limiter should be created with max: 5 from env
+
+      // Clean up
+      if (originalEnv) {
+        process.env.STREAM_CREATE_RATE_LIMIT = originalEnv;
+      } else {
+        delete process.env.STREAM_CREATE_RATE_LIMIT;
+      }
+    });
+
+    it('should default to 10 requests when STREAM_CREATE_RATE_LIMIT is not set', () => {
+      const originalEnv = process.env.STREAM_CREATE_RATE_LIMIT;
+      delete process.env.STREAM_CREATE_RATE_LIMIT;
+
+      // The limiter should be created with max: 10 by default
+      const limiter = createStreamRateLimiter({ windowMs: 10000 });
+
+      // Clean up
+      if (originalEnv) {
+        process.env.STREAM_CREATE_RATE_LIMIT = originalEnv;
+      }
+    });
+  });
+
+  describe('Error Response Format', () => {
+    it('should return proper error response when rate limited', async () => {
+      const limiter = createStreamRateLimiter({ windowMs: 10000, max: 1 });
+
+      app.post(
+        '/streams',
+        mockAuthMiddleware('GERROR123'),
+        limiter,
+        (req: Request, res: Response) => res.status(201).json({ success: true })
+      );
+
+      // Exceed limit
+      await request(app).post('/streams').set('Content-Type', 'application/json');
+      const res = await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+
+      expect(res.status).toBe(429);
+      expect(res.body).toHaveProperty('error');
+      expect(res.body).toHaveProperty('message');
+      expect(typeof res.body.message).toBe('string');
+      expect(res.body.message.toLowerCase()).toContain('rate limit');
+    });
+
+    it('should include rate limit information in response headers', async () => {
+      const limiter = createStreamRateLimiter({ windowMs: 10000, max: 2 });
+
+      app.post(
+        '/streams',
+        mockAuthMiddleware('GHEADER123'),
+        limiter,
+        (req: Request, res: Response) => res.status(201).json({ success: true })
+      );
+
+      const res = await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+
+      // Should include rate limit headers
+      expect(res.headers).toHaveProperty('ratelimit-limit');
+      expect(res.headers).toHaveProperty('ratelimit-remaining');
+      expect(res.headers).toHaveProperty('ratelimit-reset');
+    });
+  });
+
+  describe('Time Window Reset', () => {
+    it('should reset rate limit after time window expires', async () => {
+      const windowMs = 100; // Very short window for testing
+      const limiter = createStreamRateLimiter({ windowMs, max: 1 });
+
+      app.post(
+        '/streams',
+        mockAuthMiddleware('GWINDOW123'),
+        limiter,
+        (req: Request, res: Response) => res.status(201).json({ success: true })
+      );
+
+      // First request succeeds
+      let res = await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+      expect(res.status).toBe(201);
+
+      // Second request fails (over limit)
+      res = await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+      expect(res.status).toBe(429);
+
+      // Wait for window to expire
+      await new Promise((resolve) => setTimeout(resolve, windowMs + 50));
+
+      // Request after window reset should succeed
+      res = await request(app)
+        .post('/streams')
+        .set('Content-Type', 'application/json');
+      expect(res.status).toBe(201);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "backend"
       ],
       "dependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
         "react-hot-toast": "^2.6.0"
       },
       "devDependencies": {
@@ -2458,6 +2459,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
       "cpu": [
@@ -2468,6 +2497,351 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@rtsao/scc": {
@@ -9007,6 +9381,23 @@
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/router": {
       "version": "2.2.0",


### PR DESCRIPTION
Closes https://github.com/LabsCrypt/flowfi/issues/423

Add Rate Limiting to Stream Creation Endpoint
Overview
Prevents stream creation spam by enforcing per-wallet rate limits. This protects the database from bloat and preserves the Soroban fee budget.

Changes
Per-wallet rate limiting: Uses authenticated wallet address (Stellar public key) as the rate limit key
Default limit: 10 stream creation requests per minute (configurable)
Authentication required: Added authentication middleware to POST /streams endpoint
Proper HTTP response: Returns 429 Too Many Requests with Retry-After header when exceeded
Implementation Details
New Middleware: backend/src/middleware/stream-rate-limiter.middleware.ts
createStreamRateLimiter(options) - Factory function for creating configurable rate limiters
streamCreationRateLimiter - Pre-configured instance for stream creation (10/min)
Reads STREAM_CREATE_RATE_LIMIT environment variable (optional, defaults to 10)
Per-wallet isolation using authenticated public key
Comprehensive logging for security monitoring
Updated Endpoint: POST /api/v1/streams
Now requires Bearer token authentication (SEP-10 Stellar)
Applies rate limiting after successful authentication
Returns proper error responses with retry information
Updated OpenAPI documentation
Testing
