### PR TITLE
Fix/multi issue 568 569 570 571

### DIFF
--- a/contracts/stream_contract/src/events.rs
+++ b/contracts/stream_contract/src/events.rs
@@ -106,7 +106,6 @@ pub struct AdminTransferredEvent {
     pub new_admin: Address,
 }
 
-/// Emitted when a stream is paused.
 /// Emitted when a sender pauses an active stream.
 ///
 /// Topic: `("stream_paused", stream_id)`

--- a/frontend/src/components/TransactionTracker.tsx
+++ b/frontend/src/components/TransactionTracker.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { Loader2, CheckCircle, XCircle, ExternalLink, RefreshCw, Clock, Ban, FileSearch } from "lucide-react";
 import toast from "react-hot-toast";
 import type { BackendStream } from "@/lib/api-types";
+import { formatAmount } from "@/utils/amount";
 
 /**
  * TransactionTracker - Shared component for tracking on-chain transaction lifecycle
@@ -424,14 +425,6 @@ function renderChanges(prev: BackendStream, current: BackendStream) {
   }
 
   return changes;
-}
-
-// Helper to format amounts
-function formatAmount(raw: bigint, decimals: number): string {
-  const divisor = BigInt(10 ** decimals);
-  const whole = raw / divisor;
-  const fraction = (raw % divisor).toString().padStart(decimals, "0").replace(/0+$/, "");
-  return fraction ? `${whole}.${fraction}` : whole.toString();
 }
 
 // Hook for using transaction tracker in components

--- a/frontend/src/components/dashboard/StreamDetailsModal.tsx
+++ b/frontend/src/components/dashboard/StreamDetailsModal.tsx
@@ -26,7 +26,7 @@ export const StreamDetailsModal: React.FC<StreamDetailsModalProps> = ({
         return () => window.removeEventListener("keydown", handleEscape);
     }, [onClose]);
 
-    const progress = (stream.withdrawn / stream.deposited) * 100;
+    const progress = stream.deposited > 0 ? Math.min(100, Math.max(0, (stream.withdrawn / stream.deposited) * 100)) : 0;
     const remaining = stream.deposited - stream.withdrawn;
 
     return (
@@ -45,6 +45,7 @@ export const StreamDetailsModal: React.FC<StreamDetailsModalProps> = ({
                     </div>
                     <button
                         onClick={onClose}
+                        aria-label="Close"
                         className="p-2 rounded-full hover:bg-white/10 text-slate-400 transition-colors"
                     >
                         <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -38,29 +38,34 @@ export const Button: React.FC<ButtonProps> = ({
         <button
             className={`${baseStyles} ${variants[variant]} ${sizes[size]} ${glowStyles} ${className}`}
             disabled={disabled || loading}
+            aria-busy={loading}
             {...props}
         >
             {loading && (
-                <svg
-                    className="animate-spin -ml-1 mr-2 h-4 w-4 text-current"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                >
-                    <circle
-                        className="opacity-25"
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        stroke="currentColor"
-                        strokeWidth="4"
-                    />
-                    <path
-                        className="opacity-75"
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    />
-                </svg>
+                <>
+                    <svg
+                        aria-hidden="true"
+                        className="animate-spin -ml-1 mr-2 h-4 w-4 text-current"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                    >
+                        <circle
+                            className="opacity-25"
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            stroke="currentColor"
+                            strokeWidth="4"
+                        />
+                        <path
+                            className="opacity-75"
+                            fill="currentColor"
+                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        />
+                    </svg>
+                    <span className="sr-only">Loading</span>
+                </>
             )}
             {children}
         </button>


### PR DESCRIPTION
## Description

Four small, independent fixes across contracts and frontend: a duplicate doc comment, two accessibility gaps, and a duplicate utility function.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Refactoring (no functional changes)

## Related Issues

Closes #568 , Closes #569 , Closes #570 , Closes #571 

## Changes Made

### #568 — `contracts/stream_contract/src/events.rs`
- Removed the redundant first line (`/// Emitted when a stream is paused.`) from the `StreamPausedEvent` doc comment, keeping the more precise second line (`/// Emitted when a sender pauses an active stream.`).

### #569 — `frontend/src/components/ui/Button.tsx`
- Added `aria-busy={loading}` to the `<button>` element so screen readers announce the in-progress state.
- Marked the spinner SVG `aria-hidden="true"` to suppress its meaningless announcement.
- Added a `<span className="sr-only">Loading</span>` alongside the spinner so assistive technology reads a meaningful label when `loading` is true.

### #570 — `frontend/src/components/dashboard/StreamDetailsModal.tsx`
- Guarded the progress calculation: `deposited > 0 ? Math.min(100, Math.max(0, (withdrawn / deposited) * 100)) : 0` — was `NaN`/`Infinity` when `deposited === 0`.
- Added `aria-label="Close"` to the × close button, consistent with other modals in the app.

### #571 — `frontend/src/components/TransactionTracker.tsx`
- Imported `formatAmount` from the shared `@/utils/amount` utility.
- Deleted the private `formatAmount(raw, decimals)` at the bottom of the file. The local copy used `BigInt(10 ** decimals)` which is fragile for `decimals > 15`; the shared util uses the safe `10n ** BigInt(decimals)` form.

## Testing

### Test Coverage
- [x] Manual testing performed

### Test Steps

**#568**
1. `cd contracts && cargo build` — confirms the contract still compiles cleanly.

**#569**
1. Trigger any loading button (create stream, withdraw, top-up, cancel).
2. Inspect with browser DevTools: `aria-busy="true"` present on `<button>`, spinner has `aria-hidden="true"`, and a `.sr-only` "Loading" span is in the DOM.
3. Use VoiceOver / NVDA — "Loading" is announced when the button enters loading state.

**#570**
1. Open Stream Details for a stream with `deposited === 0` — progress bar renders at 0% (was broken/`NaN` width).
2. Confirm the × button is announced as "Close" by a screen reader.

**#571**
1. Trigger a transaction and let it reach the `confirmed` state — the "Summary of Changes" section renders amounts correctly.
2. `cd frontend && npm run build` — no TypeScript errors in `TransactionTracker.tsx`.

## Screenshots/Demo

No visual regression — the spinner appearance, modal layout, and transaction tracker UI are unchanged.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked for breaking changes and documented them if applicable

## Additional Notes

- Issue #571 defers to whichever path the `lib/amount` vs `utils/amount` consolidation (#520) settles on; `@/utils/amount` was chosen as it is the more complete file and is already used by the majority of components and the test suite.
- The Tailwind `bg-gradient-to-br` → `bg-linear-to-br` IDE suggestion in `StreamDetailsModal.tsx` is a pre-existing lint suggestion unrelated to this PR and is left untouched per the "out of scope" constraint.