### PR TITLE
fix(frontend): correct formatTokenAmount in IncomingStreams to use In…

### DIFF
--- a/frontend/src/components/IncomingStreams.tsx
+++ b/frontend/src/components/IncomingStreams.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import type { Stream } from '@/lib/dashboard';
 import { useStreamingAmount } from '@/hooks/useStreamingAmount';
 import toast from 'react-hot-toast';
-import { formatAmount } from '@/lib/amount';
+
 
 interface IncomingStreamsProps {
     streams: Stream[];
@@ -12,9 +12,20 @@ interface IncomingStreamsProps {
     withdrawingStreamId?: string | null;
 }
 
-function formatTokenAmount(value: number, decimals: number = 7): string {
+/**
+ * Format an already-human-scaled token amount (e.g. 10.5) for display.
+ *
+ * Values coming from the Stream interface have already been divided by 1e7
+ * (stroops → token units) by the dashboard mapper, so we must NOT re-scale
+ * them through formatAmount. Instead we format the number directly using
+ * Intl.NumberFormat, consistent with IncomingStreamCard.
+ */
+function formatTokenAmount(value: number, maximumFractionDigits = 7): string {
     if (!Number.isFinite(value)) return '0.0000000';
-    return formatAmount(BigInt(Math.floor(value)), decimals);
+    return new Intl.NumberFormat('en-US', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits,
+    }).format(value);
 }
 
 const ClaimableAmount: React.FC<{ stream: Stream }> = ({ stream }) => {


### PR DESCRIPTION
…tl.NumberFormat

## Summary

Fixes the `formatTokenAmount` helper in `IncomingStreams.tsx` which was
double-scaling already-human-readable token amounts, causing the
**Deposited**, **Withdrawn**, and **Claimable** columns in the incoming-streams
table to display wildly wrong (tiny) values.

Closes #575

---

## Root Cause

`Stream` values (`deposited`, `withdrawn`, `ratePerSecond`, `claimable`) are
already human-scaled **token amounts** — the dashboard mapper in
`lib/dashboard.ts` divides raw stroops by `1e7` before storing them on the
`Stream` object:

```ts
// lib/dashboard.ts
const STROOPS_DIVISOR = 1e7;
function toTokenAmount(raw: string): number {
  return parseFloat(raw) / STROOPS_DIVISOR;
}
```

The old `formatTokenAmount` in `IncomingStreams.tsx` then passed these values
through `formatAmount(BigInt(Math.floor(value)), 7)`, which re-interpreted
them as raw base units and divided by `1e7` a **second time**:

```ts
// ❌ BEFORE — double-scales an already-human number
function formatTokenAmount(value: number, decimals: number = 7): string {
  if (!Number.isFinite(value)) return '0.0000000';
  return formatAmount(BigInt(Math.floor(value)), decimals);
}
```

**Effect:** `10.5` XLM → `Math.floor(10.5)` = `10` → `BigInt(10)` →
`formatAmount` divides by `1e7` → `0.0000010`. Every amount in the table
was seven orders of magnitude too small.

---

## Fix

Replace the broken helper with a direct `Intl.NumberFormat` call — the same
approach already used in `IncomingStreamCard.tsx`:

```ts
// ✅ AFTER — formats the human-scaled number directly
function formatTokenAmount(value: number, maximumFractionDigits = 7): string {
  if (!Number.isFinite(value)) return '0.0000000';
  return new Intl.NumberFormat('en-US', {
    minimumFractionDigits: 0,
    maximumFractionDigits,
  }).format(value);
}
```

Also removes the now-unused `import { formatAmount } from '@/lib/amount'`.

---

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/components/IncomingStreams.tsx` | Fix `formatTokenAmount`; remove dead `formatAmount` import |

---

## Before / After

| Value (human-scaled) | Before (broken) | After (fixed) |
|---|---|---|
| `10.5` | `0.0000010` | `10.5` |
| `1234.567` | `0.0001234` | `1,234.567` |
| `0.0000001` | `0.0000000` | `0.0000001` |
| `Infinity` / `NaN` | `0.0000000` | `0.0000000` |

---

## Testing

- [x] Manually verified Deposited / Withdrawn / Claimable columns render
  correct magnitudes in the incoming-streams table
- [x] `Infinity` / `NaN` guard still returns `'0.0000000'`
- [x] Locale formatting (`1,234.567`) consistent with `IncomingStreamCard`
- [x] Removed `formatAmount` import causes no TypeScript errors

---

## Out of Scope

- Dashboard token/status mapping (tracked separately in #553)

