### PR TITLE
fix: dead Log In button, missing rel, window.location nav, missing AbortController

### DIFF
--- a/frontend/src/app/activity/page.tsx
+++ b/frontend/src/app/activity/page.tsx
@@ -32,7 +32,7 @@ export default function ActivityPage() {
   const [hasMore, setHasMore] = useState(true);
 
   const fetchActivity = useCallback(
-    async (pageNum: number, tab: string, append: boolean = false) => {
+    async (pageNum: number, tab: string, append: boolean = false, signal?: AbortSignal) => {
       if (!session?.publicKey) return;
       setLoading(true);
 
@@ -43,7 +43,7 @@ export default function ActivityPage() {
           `${API_BASE_URL}/v1/events?address=${encodeURIComponent(session.publicKey)}` +
           `&page=${pageNum}&limit=${PAGE_SIZE}${typeQuery}`;
 
-        const response = await fetch(url);
+        const response = await fetch(url, { signal });
         if (!response.ok) {
           throw new Error(`Failed to fetch activity (${response.status})`);
         }
@@ -62,6 +62,7 @@ export default function ActivityPage() {
           setHasMore(next.length === PAGE_SIZE);
         }
       } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") return;
         console.error("Failed to fetch activity:", error);
         if (!append) setEvents([]);
         setHasMore(false);
@@ -73,10 +74,11 @@ export default function ActivityPage() {
   );
 
   useEffect(() => {
-    if (status === "connected") {
-      setPage(1);
-      fetchActivity(1, activeTab, false);
-    }
+    if (status !== "connected") return;
+    const controller = new AbortController();
+    setPage(1);
+    fetchActivity(1, activeTab, false, controller.signal);
+    return () => controller.abort();
   }, [activeTab, status, fetchActivity]);
 
   const loadMore = () => {

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -52,9 +52,6 @@ export const Navbar = () => {
         {status === "connected" && session?.publicKey && (
           <NotificationDropdown publicKey={session.publicKey} />
         )}
-        <Button variant="ghost" className="hidden sm:inline-flex">
-          Log In
-        </Button>
         <WalletButton />
       </div>
     </nav>

--- a/frontend/src/components/NotificationDropdown.tsx
+++ b/frontend/src/components/NotificationDropdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
 import { useStreamEvents } from '@/hooks/useStreamEvents';
 import { formatAmount } from '@/lib/amount';
 import { Button } from './ui/Button';
@@ -19,6 +20,7 @@ interface NotificationItem {
 }
 
 export const NotificationDropdown: React.FC<NotificationDropdownProps> = ({ publicKey }) => {
+    const router = useRouter();
     const [isOpen, setIsOpen] = useState(false);
     const [notifications, setNotifications] = useState<NotificationItem[]>([]);
     const [isLoading, setIsLoading] = useState(false);
@@ -190,7 +192,8 @@ export const NotificationDropdown: React.FC<NotificationDropdownProps> = ({ publ
                             size="sm"
                             className="w-full text-xs"
                             onClick={() => {
-                                window.location.href = '/activity';
+                                setIsOpen(false);
+                                router.push('/activity');
                             }}
                         >
                             View All Activity

--- a/frontend/src/components/dashboard/ActivityHistory.tsx
+++ b/frontend/src/components/dashboard/ActivityHistory.tsx
@@ -153,6 +153,7 @@ export const ActivityHistory: React.FC<ActivityHistoryProps> = ({
                   <a
                     href={`https://stellar.expert/explorer/testnet/tx/${event.transactionHash}`}
                     target="_blank"
+                    rel="noopener noreferrer"
                     className="text-slate-500 hover:text-white transition-colors"
                     title="View on Explorer"
                   >


### PR DESCRIPTION
Closes #560 
Closes #561 
Closes #562 
Closes #563 

## What changed and why

**#562 — Navbar: remove dead Log In button**
The `Log In` button rendered with no `onClick` or `href` — clicking it did nothing. `WalletButton` is the real auth entry point so the orphaned button is removed.

**#560 — ActivityHistory: add `rel="noopener noreferrer"` to Stellar Expert link**
The external explorer anchor had `target="_blank"` with no `rel`, exposing the app to reverse-tabnabbing. Fixed in `ActivityHistory.tsx`. A grep confirmed every other `target="_blank"` link in the codebase already carries the correct `rel`.

**#561 — NotificationDropdown: replace `window.location.href` with `router.push`**
The "View All Activity" button was forcing a full-page reload, discarding SPA state (wallet context, React Query cache, SSE connection). Now uses `useRouter().push('/activity')` from `next/navigation` and closes the dropdown before navigating.

**#563 — Activity page: add AbortController cleanup to fetch**
`fetchActivity` had no abort signal, so rapidly switching tabs or unmounting mid-flight left stale in-flight requests that could race `setEvents`/`setHasMore`. An `AbortController` is now created in the effect, its `signal` passed to `fetch`, and `abort()` called on cleanup. `AbortError` is silently ignored.

## Files changed

- `frontend/src/components/Navbar.tsx`
- `frontend/src/components/dashboard/ActivityHistory.tsx`
- `frontend/src/components/NotificationDropdown.tsx`
- `frontend/src/app/activity/page.tsx`

## Test plan

- [ ] Navbar no longer shows a Log In button; WalletButton still renders
- [ ] ActivityHistory explorer link opens in a new tab without exposing `window.opener`
- [ ] NotificationDropdown "View All Activity" navigates without a full reload and closes the dropdown
- [ ] Rapid tab switching on the activity page produces no stale-response races or unmount warnings