### PR TITLE
fix(frontend): correct inverted amount validation error condition (#551)

### DIFF
--- a/frontend/src/app/streams/create/page.tsx
+++ b/frontend/src/app/streams/create/page.tsx
@@ -85,6 +85,13 @@ export default function CreateStreamPage() {
     }
   };
 
+  // Inline validation feedback for the amount field. validateAmountInput
+  // returns an error message when invalid and null when valid. Only show it
+  // once the user has typed something — the empty case is handled on submit.
+  const amountError = formData.amount
+    ? validateAmountInput(formData.amount, TOKEN_DECIMALS)
+    : null;
+
   return (
     <div className="container mx-auto max-w-2xl px-4 py-12">
       <Link
@@ -152,10 +159,8 @@ export default function CreateStreamPage() {
                 }}
                 required
               />
-              {formData.amount && !validateAmountInput(formData.amount, TOKEN_DECIMALS) && (
-                <p className="text-xs text-red-400 mt-1">
-                  Amount must be greater than 0 with max {TOKEN_DECIMALS} decimals
-                </p>
+              {amountError && (
+                <p className="text-xs text-red-400 mt-1">{amountError}</p>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Description
The create-stream amount field's inline error used an inverted condition: it rendered when `!validateAmountInput(...)` was truthy. Since `validateAmountInput` returns an error *string* when invalid and `null` when valid, `!validateAmountInput(...)` is truthy exactly when the input is **valid** — so the red error showed for good input and hid for bad input. This corrects the condition and shows the actual validation message.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update

## Related Issues
Closes #551

## Changes Made
- `frontend/src/app/streams/create/page.tsx`: compute the validation result once into a derived `amountError` (`null` when valid, message when invalid) and render the error only when it is non-null, displaying the returned message instead of a hardcoded string. Kept the "only after the user types" behavior (the empty case is already handled by the submit handler, which toasts "Amount is required"), so the pristine field is not nagged on load.

## Testing
- `npx vitest run` → 74/74 pass
- `npx tsc --noEmit` → 0 errors
- `npm run lint` → 0 errors (5 pre-existing warnings in untouched files)
- Manual logic verification of `amountError` for each input:
  | Input | `validateAmountInput` | Inline error shown |
  |---|---|---|
  | empty (pristine) | — (guarded) | none |
  | `0` / `0.00` | "Amount must be greater than 0" | yes, that message |
  | valid (e.g. `10.5`) | `null` | none |
  | too many decimals | "Amount cannot have more than 7 decimal places" | yes (note: the input's onChange already blocks typing past 7 dp, so this is defense-in-depth) |

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

> No automated test added: this is a presentational wiring fix in a heavy client page (wallet context / Soroban / router) with no existing test harness, and the underlying `validateAmountInput` logic is already unit-tested. The fix is the corrected boolean condition + message passthrough.

### Test Steps
1. Open `/streams/create` and focus the Amount field.
2. Type a valid amount (e.g. `10`) → no red error.
3. Type `0` → red error "Amount must be greater than 0".
4. Clear the field → no inline error (submit still blocks with a toast).

## Screenshots/Demo
Not attached: one-line conditional fix, no visual restyling, and the app's build fetches Google Fonts at build time which is blocked in my sandbox. Behavior is described in Test Steps.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where helpful
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked for breaking changes (none)

## Additional Notes
Branch `fix/create-stream-amount-error-551`; conventional commit; out-of-scope wizard amount step left untouched per the issue.
