### PR TITLE
fix(frontend): derive create-stream token options from TOKEN_ADDRESSES (#552)

### DIFF
--- a/frontend/src/app/streams/create/page.tsx
+++ b/frontend/src/app/streams/create/page.tsx
@@ -6,7 +6,8 @@ import {
   toBaseUnits,
   toDurationSeconds,
   getTokenAddress,
-  toSorobanErrorMessage
+  toSorobanErrorMessage,
+  TOKEN_ADDRESSES
 } from "@/lib/soroban";
 import { hasValidPrecision, validateAmountInput } from "@/utils/amount";
 import { toast } from "react-hot-toast";
@@ -126,9 +127,11 @@ export default function CreateStreamPage() {
                 value={formData.token}
                 onChange={(e) => setFormData({ ...formData, token: e.target.value })}
               >
-                <option value="XLM">XLM</option>
-                <option value="USDC">USDC</option>
-                <option value="FLOW">FLOW</option>
+                {Object.keys(TOKEN_ADDRESSES).map((symbol) => (
+                  <option key={symbol} value={symbol}>
+                    {symbol}
+                  </option>
+                ))}
               </select>
             </div>
             <div className="space-y-2">


### PR DESCRIPTION
## Description
The create-stream token `<select>` offered `XLM`, `USDC`, `FLOW`, but `getTokenAddress` only resolves the `TOKEN_ADDRESSES` keys (`USDC`, `XLM`, `EURC`). So selecting **FLOW** threw `SorobanCallError("Unsupported token: FLOW")` on submit, and the supported **EURC** wasn't selectable. This derives the options directly from `TOKEN_ADDRESSES`, so the list can never drift from what the app can actually resolve.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update

## Related Issues
Closes #552

## Changes Made
- `frontend/src/app/streams/create/page.tsx`: import `TOKEN_ADDRESSES` and render the token `<option>`s from `Object.keys(TOKEN_ADDRESSES)` instead of a hardcoded `XLM/USDC/FLOW` list. The options are now `USDC/XLM/EURC` — exactly the symbols `getTokenAddress` resolves. The default `formData.token` (`"XLM"`) remains a valid key, so the preselected value is unchanged.

## Testing
- `npx vitest run` → 74/74 pass
- `npx tsc --noEmit` → 0 errors
- `npm run lint` → 0 errors (5 pre-existing warnings in untouched files)
- Manual reasoning: every rendered option value is a `TOKEN_ADDRESSES` key, so `getTokenAddress(formData.token)` resolves for all of them and the `Unsupported token` path is unreachable from the select. FLOW is no longer offered; EURC now is.

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

> No automated test added: presentational fix in a heavy client page (wallet/Soroban/router) with no existing test harness; correctness is structural (options are now the resolvable keys themselves).

### Test Steps
1. Open `/streams/create`.
2. Token dropdown shows `USDC`, `XLM`, `EURC` (no `FLOW`).
3. Select `EURC`, fill the form, submit → no `Unsupported token` error.

## Screenshots/Demo
Not attached: small option-list change, and the app's build fetches Google Fonts (network-blocked in my sandbox). Behavior is described in Test Steps.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked for breaking changes (none)

## Additional Notes
Adding new token contracts is out of scope per the issue. Branch off current `main`; conventional commit.

### CI note
`Backend CI` / `Backend npm test` may be red due to pre-existing backend integration-test failures (blanket 401) tracked in #608 — unrelated to this PR, which only changes `frontend/src/app/streams/create/page.tsx`.
