### PR TITLE
fix(frontend): resolve dashboard token symbol and map Paused/Cancelled status (#553)

### DIFF
--- a/frontend/src/__tests__/dashboard.test.ts
+++ b/frontend/src/__tests__/dashboard.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { mapBackendStreamToFrontend } from "../lib/dashboard";
+import { TOKEN_ADDRESSES } from "../lib/soroban";
+import type { BackendStream, BackendStreamEvent } from "../lib/api-types";
+
+function makeStream(overrides: Partial<BackendStream> = {}): BackendStream {
+  return {
+    id: "db-1",
+    streamId: 1,
+    sender: "GSENDER000000000000000000000000000000000000000000000000",
+    recipient: "GRECIPIENT0000000000000000000000000000000000000000000",
+    tokenAddress: TOKEN_ADDRESSES.USDC,
+    ratePerSecond: "1000000",
+    depositedAmount: "100000000",
+    withdrawnAmount: "20000000",
+    startTime: 1_700_000_000,
+    lastUpdateTime: 1_700_000_500,
+    isActive: true,
+    isPaused: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const cancelledEvent: BackendStreamEvent = {
+  id: "evt-1",
+  streamId: 1,
+  eventType: "CANCELLED",
+  amount: null,
+  transactionHash: "hash",
+  ledgerSequence: 1,
+  timestamp: 1_700_000_600,
+  metadata: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("mapBackendStreamToFrontend", () => {
+  describe("token label", () => {
+    it("resolves known token addresses to their symbol", () => {
+      expect(mapBackendStreamToFrontend(makeStream({ tokenAddress: TOKEN_ADDRESSES.XLM }), "G").token).toBe("XLM");
+      expect(mapBackendStreamToFrontend(makeStream({ tokenAddress: TOKEN_ADDRESSES.USDC }), "G").token).toBe("USDC");
+      expect(mapBackendStreamToFrontend(makeStream({ tokenAddress: TOKEN_ADDRESSES.EURC }), "G").token).toBe("EURC");
+    });
+
+    it("falls back to a shortened address for unknown tokens", () => {
+      const addr = "CUNKNOWNTOKENADDRESS000000000000000000000000000000000000";
+      expect(mapBackendStreamToFrontend(makeStream({ tokenAddress: addr }), "G").token).toBe(
+        `${addr.slice(0, 6)}...${addr.slice(-4)}`,
+      );
+    });
+
+    it("never returns the placeholder 'TOKEN'", () => {
+      expect(mapBackendStreamToFrontend(makeStream(), "G").token).not.toBe("TOKEN");
+    });
+  });
+
+  describe("status", () => {
+    it("is Paused when the stream is paused", () => {
+      expect(mapBackendStreamToFrontend(makeStream({ isPaused: true }), "G").status).toBe("Paused");
+    });
+
+    it("is Active when active and not paused", () => {
+      expect(mapBackendStreamToFrontend(makeStream({ isActive: true, isPaused: false }), "G").status).toBe("Active");
+    });
+
+    it("is Cancelled when inactive with a CANCELLED event", () => {
+      const s = makeStream({ isActive: false, isPaused: false, events: [cancelledEvent] });
+      expect(mapBackendStreamToFrontend(s, "G").status).toBe("Cancelled");
+    });
+
+    it("is Completed when inactive without a CANCELLED event", () => {
+      const s = makeStream({ isActive: false, isPaused: false, events: [] });
+      expect(mapBackendStreamToFrontend(s, "G").status).toBe("Completed");
+    });
+
+    it("is Completed when inactive and events are absent", () => {
+      const s = makeStream({ isActive: false, isPaused: false });
+      expect(mapBackendStreamToFrontend(s, "G").status).toBe("Completed");
+    });
+  });
+});

--- a/frontend/src/lib/dashboard.ts
+++ b/frontend/src/lib/dashboard.ts
@@ -1,5 +1,6 @@
-import type { BackendStream, BackendStreamEvent } from "./api-types";
+import type { BackendStream } from "./api-types";
 import { getStreamsEndpointCandidates, toTokenAmount } from "./api/_shared";
+import { TOKEN_ADDRESSES } from "./soroban";
 
 export interface ActivityItem {
   id: string;
@@ -50,6 +51,31 @@ function shortenAddress(address: string): string {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
 }
 
+/**
+ * Resolves a token contract address to its symbol (XLM/USDC/EURC), falling
+ * back to a shortened address when the token is unknown.
+ */
+function resolveTokenLabel(tokenAddress: string): string {
+  const entry = Object.entries(TOKEN_ADDRESSES).find(
+    ([, address]) => address === tokenAddress,
+  );
+
+  return entry?.[0] ?? shortenAddress(tokenAddress);
+}
+
+/**
+ * Derives the display status from the backend flags. A paused stream reads
+ * "Paused"; an active one "Active". An inactive stream is "Cancelled" when a
+ * CANCELLED event is present, otherwise it ran to completion ("Completed").
+ */
+function mapStreamStatus(s: BackendStream): Stream["status"] {
+  if (s.isPaused) return "Paused";
+  if (s.isActive) return "Active";
+
+  const wasCancelled = s.events?.some((e) => e.eventType === "CANCELLED") ?? false;
+  return wasCancelled ? "Cancelled" : "Completed";
+}
+
 async function fetchStreams(
   publicKey: string,
   role: "sender" | "recipient",
@@ -81,7 +107,7 @@ async function fetchStreams(
 /**
  * Maps a backend stream object to the frontend Stream interface.
  */
-function mapBackendStreamToFrontend(s: BackendStream, counterparty: string): Stream {
+export function mapBackendStreamToFrontend(s: BackendStream, counterparty: string): Stream {
   const deposited = toTokenAmount(s.depositedAmount);
   const withdrawn = toTokenAmount(s.withdrawnAmount);
   const ratePerSecond = toTokenAmount(s.ratePerSecond);
@@ -90,8 +116,8 @@ function mapBackendStreamToFrontend(s: BackendStream, counterparty: string): Str
     id: s.streamId.toString(),
     recipient: shortenAddress(counterparty),
     amount: deposited,
-    token: "TOKEN",
-    status: s.isActive ? "Active" : "Completed",
+    token: resolveTokenLabel(s.tokenAddress),
+    status: mapStreamStatus(s),
     deposited,
     withdrawn,
     date: new Date(s.startTime * 1000).toISOString().split("T")[0],


### PR DESCRIPTION
## Description
`mapBackendStreamToFrontend` in `frontend/src/lib/dashboard.ts` had two display bugs feeding the dashboard:
1. `token` was hardcoded to `"TOKEN"`, so every row/card showed literally "TOKEN" instead of the real symbol.
2. `status` was `s.isActive ? "Active" : "Completed"`, so it never produced `"Paused"` or `"Cancelled"` — the Paused tab (which filters `status === "Paused"`) was always empty, and cancelled streams showed as "Completed".

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update

## Related Issues
Closes #553

## Changes Made
- `frontend/src/lib/dashboard.ts`:
  - Add `resolveTokenLabel(tokenAddress)` — resolves the symbol from `TOKEN_ADDRESSES` (mirroring `lib/api/streams.ts`), falling back to a shortened address for unknown tokens.
  - Add `mapStreamStatus(s)` — `Paused` when `isPaused`, `Active` when active, otherwise `Cancelled` (when a `CANCELLED` event is present on the stream) or `Completed`.
  - Use both in `mapBackendStreamToFrontend` (replacing the hardcoded `"TOKEN"` and the binary status). Exported the function for unit testing.
  - Drop the now-unused `BackendStreamEvent` import (cleared a pre-existing lint warning).
- `frontend/src/__tests__/dashboard.test.ts`: new unit tests for token resolution (known symbols, unknown fallback, never `"TOKEN"`) and status mapping (Paused / Active / Cancelled-via-event / Completed / Completed-when-events-absent).

## Testing
- `npx vitest run` → 82/82 pass (8 new)
- `npx tsc --noEmit` → 0 errors
- `npm run lint` → 0 errors (and one fewer warning)

### Test Coverage
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed (verified the pure mapper output for each status/token case via the new tests)

### Test Steps
1. Load the dashboard with streams in different states.
2. Token column shows real symbols (XLM/USDC/EURC), not "TOKEN".
3. A paused stream appears under the Paused tab; a cancelled stream reads "Cancelled".

## Screenshots/Demo
Not attached: pure data-mapping change with no markup change, and the app build fetches Google Fonts (network-blocked in my sandbox). Behavior covered by unit tests + Test Steps.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly the new helpers
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked for breaking changes (none)

## Additional Notes
The incoming-streams mapper in `lib/api/streams.ts` is out of scope per the issue (it already resolves token + status); to respect that scope I added a small local `resolveTokenLabel` in `dashboard.ts` rather than modifying/exporting from `streams.ts`. Cancelled-vs-Completed is detected via the stream's `CANCELLED` event ("use events or available flags" per the issue); when the list payload carries no events it safely defaults to "Completed".

### CI note
`Backend CI` / `Backend npm test` may be red due to pre-existing backend integration-test failures (blanket 401) tracked in #608 — unrelated to this PR, which changes only frontend dashboard mapping.
