### PR TITLE
fix(backend): repair backend CI — auth mocks targeted the wrong module

### DIFF
--- a/backend/tests/integration/streams.test.ts
+++ b/backend/tests/integration/streams.test.ts
@@ -11,16 +11,16 @@ import request from 'supertest';
 // Bypass Stellar signature verification on POST /v1/streams. The route is
 // exercised here as a stand-in for the indexer worker, so we replace the auth
 // middleware with a stub that injects a deterministic wallet.
-vi.mock('../../src/middleware/auth.middleware.js', () => ({
-  authMiddleware: (req: any, _res: any, next: any) => {
-    req.user = { publicKey: 'GTEST_USER_PUBLIC_KEY' };
-    next();
-  },
-  optionalAuthMiddleware: (req: any, _res: any, next: any) => {
-    req.user = { publicKey: 'GTEST_USER_PUBLIC_KEY' };
-    next();
-  },
-}));
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/middleware/auth.js')>();
+  return {
+    ...actual,
+    requireAuth: (req: any, _res: any, next: any) => {
+      req.user = { publicKey: 'GTEST_USER_PUBLIC_KEY' };
+      next();
+    },
+  };
+});
 
 // ─── Mocks (using vi.hoisted to ensure they are available to vi.mock) ─────────
 

--- a/backend/tests/integration/streams/cancel.test.ts
+++ b/backend/tests/integration/streams/cancel.test.ts
@@ -38,12 +38,16 @@ vi.mock('../../../src/lib/prisma.js', () => {
 });
 
 // Mock auth middleware to bypass real Stellar signature verification
-vi.mock('../../../src/middleware/auth.middleware.js', () => ({
-  authMiddleware: (req: any, res: any, next: any) => {
-    req.user = { publicKey: 'G_SENDER_123' };
-    next();
-  },
-}));
+vi.mock('../../../src/middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/middleware/auth.js')>();
+  return {
+    ...actual,
+    requireAuth: (req: any, _res: any, next: any) => {
+      req.user = { publicKey: 'G_SENDER_123' };
+      next();
+    },
+  };
+});
 
 // ─── App import (after mocks) ───────────────────────────────────────────────
 

--- a/backend/tests/integration/streams/withdraw.test.ts
+++ b/backend/tests/integration/streams/withdraw.test.ts
@@ -32,12 +32,16 @@ vi.mock('../../../src/services/sorobanService.js', () => ({
   isStale: vi.fn().mockReturnValue(false),
 }));
 
-vi.mock('../../../src/middleware/auth.middleware.js', () => ({
-  authMiddleware: (req: any, _res: any, next: any) => {
-    req.user = { publicKey: currentUser.publicKey };
-    next();
-  },
-}));
+vi.mock('../../../src/middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/middleware/auth.js')>();
+  return {
+    ...actual,
+    requireAuth: (req: any, _res: any, next: any) => {
+      req.user = { publicKey: currentUser.publicKey };
+      next();
+    },
+  };
+});
 
 import app from '../../../src/app.js';
 

--- a/backend/tests/integration/top-up.test.ts
+++ b/backend/tests/integration/top-up.test.ts
@@ -58,12 +58,16 @@ vi.mock('../../src/services/sorobanService.js', () => ({
   cancelStream: vi.fn(),
 }));
 
-vi.mock('../../src/middleware/auth.middleware.js', () => ({
-  authMiddleware: vi.fn((req: any, _res: any, next: any) => {
-    req.user = { publicKey: req.headers['x-test-caller'] ?? SENDER };
-    next();
-  }),
-}));
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/middleware/auth.js')>();
+  return {
+    ...actual,
+    requireAuth: vi.fn((req: any, _res: any, next: any) => {
+      req.user = { publicKey: req.headers['x-test-caller'] ?? SENDER };
+      next();
+    }),
+  };
+});
 
 // App import after mocks
 import app from '../../src/app.js';

--- a/backend/tests/stream.test.ts
+++ b/backend/tests/stream.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 
-vi.mock('../src/middleware/auth.middleware.js', () => ({
-  authMiddleware: (req: any, _res: any, next: any) => {
-    req.user = { publicKey: 'GTEST_USER_PUBLIC_KEY' };
-    next();
-  },
-  optionalAuthMiddleware: (_req: any, _res: any, next: any) => next(),
-}));
+vi.mock('../src/middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/middleware/auth.js')>();
+  return {
+    ...actual,
+    requireAuth: (req: any, _res: any, next: any) => {
+      req.user = { publicKey: 'GTEST_USER_PUBLIC_KEY' };
+      next();
+    },
+  };
+});
 
 vi.mock('../src/middleware/stream-rate-limiter.middleware.js', () => ({
   streamCreationRateLimiter: (_req: any, _res: any, next: any) => next(),


### PR DESCRIPTION
## Problem

After the recent backend coverage tests were merged, the **Backend CI** job is red: 22 tests fail across `stream`, `top-up`, `cancel`, `withdraw`, and the `streams` integration suite. Every authenticated request returns **401** instead of the expected status.

## Root cause

The route integration tests bypass auth by mocking `src/middleware/auth.middleware.js`, which only re-exports `authMiddleware` as an alias. The routes import `requireAuth` **directly from `src/middleware/auth.js`**, so the mock never intercepts anything and the real JWT middleware rejects the test requests.

## Fix

Point each affected test's `vi.mock` at `src/middleware/auth.js` and override `requireAuth`, using `importOriginal` so the module's other exports (`requireAdmin`, `issueChallenge`, `verifyChallenge`, `verifyJwt`) stay intact for the rest of the app.

Test-only change — no production code touched.

## Verification

Backend test suite locally against Postgres:

- `Test Files  36 passed (36)`
- `Tests  184 passed (184)`
- Coverage: statements 69.94 / branches 67.02 / functions 72.34 / lines 69.94 — all above the 60% gate.

Frontend (lint/test/build) and contracts (95 tests, tarpaulin 98.76%) jobs remain green.