### PR TITLE
fix: swagger doc/route mismatch, schema drift, security schemes, and 401 auth test failures

### DIFF
--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -76,6 +76,18 @@ See [Sandbox Mode Documentation](../docs/SANDBOX_MODE.md) for details.`,
           scheme: 'bearer',
           bearerFormat: 'JWT',
           description: 'JSON Web Token issued by /v1/auth/verify after completing the SEP-10 challenge flow.'
+        },
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description: 'Alias for BearerAuth — used by route-level security annotations.'
+        },
+        adminAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description: 'Admin JWT — the token subject must match ADMIN_PUBLIC_KEY.'
         }
       },
       schemas: {
@@ -165,6 +177,28 @@ See [Sandbox Mode Documentation](../docs/SANDBOX_MODE.md) for details.`,
               description: 'Stream active status',
               example: true,
             },
+            isPaused: {
+              type: 'boolean',
+              description: 'Whether the stream is currently paused',
+              example: false,
+            },
+            pausedAt: {
+              type: 'integer',
+              nullable: true,
+              description: 'Ledger timestamp when the stream was last paused (Unix), null if not paused',
+              example: null,
+            },
+            totalPausedDuration: {
+              type: 'integer',
+              description: 'Cumulative seconds the stream has spent paused',
+              example: 0,
+            },
+            endTime: {
+              type: 'integer',
+              nullable: true,
+              description: 'Ledger timestamp when the stream ended (Unix), null if still active',
+              example: null,
+            },
             createdAt: {
               type: 'string',
               format: 'date-time',
@@ -189,7 +223,7 @@ See [Sandbox Mode Documentation](../docs/SANDBOX_MODE.md) for details.`,
             },
             eventType: {
               type: 'string',
-              enum: ['CREATED', 'TOPPED_UP', 'WITHDRAWN', 'CANCELLED', 'COMPLETED'],
+              enum: ['CREATED', 'TOPPED_UP', 'WITHDRAWN', 'CANCELLED', 'COMPLETED', 'PAUSED', 'RESUMED', 'FEE_COLLECTED'],
               description: 'Type of stream event',
               example: 'TOPPED_UP',
             },

--- a/backend/src/routes/v1/stream.routes.ts
+++ b/backend/src/routes/v1/stream.routes.ts
@@ -263,13 +263,56 @@ router.post('/:streamId/withdraw', requireAuth, withdrawHandler as any);
 
 /**
  * @openapi
- * /v1/streams/{streamId}/cancel:
+ * /v1/streams/{streamId}/top-up:
  *   post:
  *     tags:
  *       - Streams
- *     summary: Cancel an active payment stream
+ *     summary: Top up a payment stream
+ *     description: Adds additional funds to an existing active stream. Only the original sender can top up.
+ *     parameters:
+ *       - in: path
+ *         name: streamId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: On-chain stream ID
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - amount
+ *             properties:
+ *               amount:
+ *                 type: string
+ *                 description: Amount to add to the stream deposit (i128 as string)
+ *                 example: '5000'
+ *     responses:
+ *       200:
+ *         description: Stream topped up successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 txHash:
+ *                   type: string
+ *                 streamId:
+ *                   type: integer
+ *                 newDepositedAmount:
+ *                   type: string
+ *       400:
+ *         description: Invalid request — amount missing or not a positive integer string
+ *       401:
+ *         description: Unauthorized - missing or invalid authentication token
+ *       403:
+ *         description: Forbidden - caller is not the stream sender
+ *       404:
+ *         description: Stream not found
  */
 router.post('/:streamId/top-up', requireAuth, topUpStreamHandler);
 router.post('/:streamId/cancel', requireAuth, cancelStreamHandler as any);

--- a/backend/tests/integration/streams.test.ts
+++ b/backend/tests/integration/streams.test.ts
@@ -11,16 +11,16 @@ import request from 'supertest';
 // Bypass Stellar signature verification on POST /v1/streams. The route is
 // exercised here as a stand-in for the indexer worker, so we replace the auth
 // middleware with a stub that injects a deterministic wallet.
-vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../src/middleware/auth.js')>();
-  return {
-    ...actual,
-    requireAuth: (req: any, _res: any, next: any) => {
-      req.user = { publicKey: 'GTEST_USER_PUBLIC_KEY' };
-      next();
-    },
-  };
-});
+// Simple factory — no importOriginal — reliable with pool:forks.
+vi.mock('../../src/middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { publicKey: 'GTEST_USER_PUBLIC_KEY' };
+    next();
+  },
+  requireAdmin: (_req: any, res: any, _next: any) => {
+    res.status(403).json({ error: 'Forbidden' });
+  },
+}));
 
 // ─── Mocks (using vi.hoisted to ensure they are available to vi.mock) ─────────
 

--- a/backend/tests/integration/streams/cancel.test.ts
+++ b/backend/tests/integration/streams/cancel.test.ts
@@ -37,17 +37,17 @@ vi.mock('../../../src/lib/prisma.js', () => {
   };
 });
 
-// Mock auth middleware to bypass real Stellar signature verification
-vi.mock('../../../src/middleware/auth.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../src/middleware/auth.js')>();
-  return {
-    ...actual,
-    requireAuth: (req: any, _res: any, next: any) => {
-      req.user = { publicKey: 'G_SENDER_123' };
-      next();
-    },
-  };
-});
+// Mock auth middleware to bypass real Stellar signature verification.
+// Uses a simple factory (no importOriginal) so it is reliable with pool:forks.
+vi.mock('../../../src/middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { publicKey: 'G_SENDER_123' };
+    next();
+  },
+  requireAdmin: (_req: any, res: any, _next: any) => {
+    res.status(403).json({ error: 'Forbidden' });
+  },
+}));
 
 // ─── App import (after mocks) ───────────────────────────────────────────────
 

--- a/backend/tests/integration/streams/withdraw.test.ts
+++ b/backend/tests/integration/streams/withdraw.test.ts
@@ -32,16 +32,16 @@ vi.mock('../../../src/services/sorobanService.js', () => ({
   isStale: vi.fn().mockReturnValue(false),
 }));
 
-vi.mock('../../../src/middleware/auth.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../src/middleware/auth.js')>();
-  return {
-    ...actual,
-    requireAuth: (req: any, _res: any, next: any) => {
-      req.user = { publicKey: currentUser.publicKey };
-      next();
-    },
-  };
-});
+// Simple factory — no importOriginal — reliable with pool:forks.
+vi.mock('../../../src/middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { publicKey: currentUser.publicKey };
+    next();
+  },
+  requireAdmin: (_req: any, res: any, _next: any) => {
+    res.status(403).json({ error: 'Forbidden' });
+  },
+}));
 
 import app from '../../../src/app.js';
 

--- a/backend/tests/integration/top-up.test.ts
+++ b/backend/tests/integration/top-up.test.ts
@@ -58,16 +58,16 @@ vi.mock('../../src/services/sorobanService.js', () => ({
   cancelStream: vi.fn(),
 }));
 
-vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../src/middleware/auth.js')>();
-  return {
-    ...actual,
-    requireAuth: vi.fn((req: any, _res: any, next: any) => {
-      req.user = { publicKey: req.headers['x-test-caller'] ?? SENDER };
-      next();
-    }),
-  };
-});
+// Simple factory — no importOriginal — reliable with pool:forks.
+vi.mock('../../src/middleware/auth.js', () => ({
+  requireAuth: vi.fn((req: any, _res: any, next: any) => {
+    req.user = { publicKey: req.headers['x-test-caller'] ?? SENDER };
+    next();
+  }),
+  requireAdmin: vi.fn((_req: any, res: any, _next: any) => {
+    res.status(403).json({ error: 'Forbidden' });
+  }),
+}));
 
 // App import after mocks
 import app from '../../src/app.js';

--- a/backend/tests/stream.test.ts
+++ b/backend/tests/stream.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 
-vi.mock('../src/middleware/auth.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../src/middleware/auth.js')>();
-  return {
-    ...actual,
-    requireAuth: (req: any, _res: any, next: any) => {
-      req.user = { publicKey: 'GTEST_USER_PUBLIC_KEY' };
-      next();
-    },
-  };
-});
+// Simple factory — no importOriginal — reliable with pool:forks.
+vi.mock('../src/middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { publicKey: 'GTEST_USER_PUBLIC_KEY' };
+    next();
+  },
+  requireAdmin: (_req: any, res: any, _next: any) => {
+    res.status(403).json({ error: 'Forbidden' });
+  },
+}));
 
 vi.mock('../src/middleware/stream-rate-limiter.middleware.js', () => ({
   streamCreationRateLimiter: (_req: any, _res: any, next: any) => next(),

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
         environment: 'node',
         globals: true,
         setupFiles: [],
+        // Provide a stable JWT_SECRET so verifyJwt is deterministic in tests.
+        // The integration test mocks replace requireAuth entirely, but a known
+        // secret means the real middleware also works if a mock is not applied.
+        env: {
+          JWT_SECRET: 'flowfi-test-secret-do-not-use-in-production',
+        },
         include: ['tests/**/*.{test,spec}.ts', 'src/__tests__/**/*.{test,spec}.ts'],
         coverage: {
             enabled: true,


### PR DESCRIPTION
Fixes #539
Fixes #540
Fixes #541
Fixes #608

## What changed

### #539 — top-up undocumented; cancel `@openapi` sat above the wrong route

`stream.routes.ts` had the `/cancel` `@openapi` block sitting directly above the top-up route registration, so the generated spec attributed cancel's documentation to top-up and left `POST /v1/streams/{streamId}/top-up` entirely undocumented.

- Replaced the misplaced block with a proper `@openapi` spec for `POST /v1/streams/{streamId}/top-up` (requestBody: `{ amount: string }`, 200/400/401/403/404 responses)
- The canonical cancel spec already lives in `controllers/stream/cancel.ts` — no duplicate needed

### #540 — `StreamEvent.eventType` enum and `Stream` pause fields out of sync

`swagger.ts` component schemas were drifting from the real models:
- Extended `StreamEvent.eventType` enum with `PAUSED`, `RESUMED`, `FEE_COLLECTED`
- Added `isPaused`, `pausedAt`, `totalPausedDuration`, `endTime` to the `Stream` schema

### #541 — `bearerAuth` / `adminAuth` security schemes undefined

Routes reference `bearerAuth` (lowercase) and `adminAuth` but only `BearerAuth` (capital) existed. Added both aliases to `components.securitySchemes` so Swagger UI renders the lock icon on every protected route.

### #608 — 22 integration tests failing with blanket 401

**Root cause**: The `async (importOriginal) => { ...actual, requireAuth: stub }` factory pattern in `vi.mock` doesn't reliably apply in Vitest's `pool: 'forks'` mode. Because `importOriginal` is async and the forked worker processes module imports before the factory resolves, the real `requireAuth` can be registered before the mock is applied — causing `dummy_token` to fail JWT verification and return `401`.

**Fix**:
- Replaced every `async (importOriginal)` factory with a plain synchronous factory that exports only `requireAuth` and `requireAdmin` stubs. Synchronous factories are guaranteed to be applied before any module imports resolve.
- Added `JWT_SECRET: 'flowfi-test-secret-...'` to `vitest.config.ts` `env` so `verifyJwt` is deterministic and the real middleware accepts properly-signed tokens even if a mock is not applied (belt-and-suspenders).

## How to verify
```bash
cd backend
npm test
# expect: 0 test failures related to 401 in the 5 integration files
```

For swagger: start the server and visit `/api-docs.json` — both `top-up` and `cancel` appear under streams, `StreamEvent.eventType` includes all 8 values, `Stream` includes pause fields, and all three security schemes are listed.