### PR TITLE
fix(backend): restore real auth.js exports in test mocks so suites load

### DIFF
--- a/backend/tests/integration/streams.test.ts
+++ b/backend/tests/integration/streams.test.ts
@@ -11,16 +11,22 @@ import request from 'supertest';
 // Bypass Stellar signature verification on POST /v1/streams. The route is
 // exercised here as a stand-in for the indexer worker, so we replace the auth
 // middleware with a stub that injects a deterministic wallet.
-// Simple factory — no importOriginal — reliable with pool:forks.
-vi.mock('../../src/middleware/auth.js', () => ({
-  requireAuth: (req: any, _res: any, next: any) => {
-    req.user = { publicKey: 'GTEST_USER_PUBLIC_KEY' };
-    next();
-  },
-  requireAdmin: (_req: any, res: any, _next: any) => {
-    res.status(403).json({ error: 'Forbidden' });
-  },
-}));
+// Preserve the module's real exports (issueChallenge, verifyChallenge,
+// verifyJwt) — auth.routes wires them up at app construction — while stubbing
+// only the middleware so requests bypass JWT verification.
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/middleware/auth.js')>();
+  return {
+    ...actual,
+    requireAuth: (req: any, _res: any, next: any) => {
+      req.user = { publicKey: 'GTEST_USER_PUBLIC_KEY' };
+      next();
+    },
+    requireAdmin: (_req: any, res: any, _next: any) => {
+      res.status(403).json({ error: 'Forbidden' });
+    },
+  };
+});
 
 // ─── Mocks (using vi.hoisted to ensure they are available to vi.mock) ─────────
 

--- a/backend/tests/integration/streams/cancel.test.ts
+++ b/backend/tests/integration/streams/cancel.test.ts
@@ -39,15 +39,19 @@ vi.mock('../../../src/lib/prisma.js', () => {
 
 // Mock auth middleware to bypass real Stellar signature verification.
 // Uses a simple factory (no importOriginal) so it is reliable with pool:forks.
-vi.mock('../../../src/middleware/auth.js', () => ({
-  requireAuth: (req: any, _res: any, next: any) => {
-    req.user = { publicKey: 'G_SENDER_123' };
-    next();
-  },
-  requireAdmin: (_req: any, res: any, _next: any) => {
-    res.status(403).json({ error: 'Forbidden' });
-  },
-}));
+vi.mock('../../../src/middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/middleware/auth.js')>();
+  return {
+    ...actual,
+    requireAuth: (req: any, _res: any, next: any) => {
+      req.user = { publicKey: 'G_SENDER_123' };
+      next();
+    },
+    requireAdmin: (_req: any, res: any, _next: any) => {
+      res.status(403).json({ error: 'Forbidden' });
+    },
+  };
+});
 
 // ─── App import (after mocks) ───────────────────────────────────────────────
 

--- a/backend/tests/integration/streams/withdraw.test.ts
+++ b/backend/tests/integration/streams/withdraw.test.ts
@@ -33,15 +33,19 @@ vi.mock('../../../src/services/sorobanService.js', () => ({
 }));
 
 // Simple factory — no importOriginal — reliable with pool:forks.
-vi.mock('../../../src/middleware/auth.js', () => ({
-  requireAuth: (req: any, _res: any, next: any) => {
-    req.user = { publicKey: currentUser.publicKey };
-    next();
-  },
-  requireAdmin: (_req: any, res: any, _next: any) => {
-    res.status(403).json({ error: 'Forbidden' });
-  },
-}));
+vi.mock('../../../src/middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/middleware/auth.js')>();
+  return {
+    ...actual,
+    requireAuth: (req: any, _res: any, next: any) => {
+      req.user = { publicKey: currentUser.publicKey };
+      next();
+    },
+    requireAdmin: (_req: any, res: any, _next: any) => {
+      res.status(403).json({ error: 'Forbidden' });
+    },
+  };
+});
 
 import app from '../../../src/app.js';
 

--- a/backend/tests/integration/top-up.test.ts
+++ b/backend/tests/integration/top-up.test.ts
@@ -58,16 +58,22 @@ vi.mock('../../src/services/sorobanService.js', () => ({
   cancelStream: vi.fn(),
 }));
 
-// Simple factory — no importOriginal — reliable with pool:forks.
-vi.mock('../../src/middleware/auth.js', () => ({
-  requireAuth: vi.fn((req: any, _res: any, next: any) => {
-    req.user = { publicKey: req.headers['x-test-caller'] ?? SENDER };
-    next();
-  }),
-  requireAdmin: vi.fn((_req: any, res: any, _next: any) => {
-    res.status(403).json({ error: 'Forbidden' });
-  }),
-}));
+// Preserve the module's real exports (issueChallenge, verifyChallenge,
+// verifyJwt) — auth.routes wires them up at app construction — while stubbing
+// only the middleware so requests bypass JWT verification.
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/middleware/auth.js')>();
+  return {
+    ...actual,
+    requireAuth: vi.fn((req: any, _res: any, next: any) => {
+      req.user = { publicKey: req.headers['x-test-caller'] ?? SENDER };
+      next();
+    }),
+    requireAdmin: vi.fn((_req: any, res: any, _next: any) => {
+      res.status(403).json({ error: 'Forbidden' });
+    }),
+  };
+});
 
 // App import after mocks
 import app from '../../src/app.js';

--- a/backend/tests/stream.test.ts
+++ b/backend/tests/stream.test.ts
@@ -1,16 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 
-// Simple factory — no importOriginal — reliable with pool:forks.
-vi.mock('../src/middleware/auth.js', () => ({
-  requireAuth: (req: any, _res: any, next: any) => {
-    req.user = { publicKey: 'GTEST_USER_PUBLIC_KEY' };
-    next();
-  },
-  requireAdmin: (_req: any, res: any, _next: any) => {
-    res.status(403).json({ error: 'Forbidden' });
-  },
-}));
+// Preserve the module's real exports (issueChallenge, verifyChallenge,
+// verifyJwt) — auth.routes wires them up at app construction — while stubbing
+// only the middleware so requests bypass JWT verification.
+vi.mock('../src/middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/middleware/auth.js')>();
+  return {
+    ...actual,
+    requireAuth: (req: any, _res: any, next: any) => {
+      req.user = { publicKey: 'GTEST_USER_PUBLIC_KEY' };
+      next();
+    },
+    requireAdmin: (_req: any, res: any, _next: any) => {
+      res.status(403).json({ error: 'Forbidden' });
+    },
+  };
+});
 
 vi.mock('../src/middleware/stream-rate-limiter.middleware.js', () => ({
   streamCreationRateLimiter: (_req: any, _res: any, next: any) => next(),


### PR DESCRIPTION
## Why

`main` is red again on the **Backend CI** job. PR #703 (swagger-docs-auth-tests) rewrote the `auth.js` mock in the five stream route test files to a plain factory:

```js
vi.mock('../src/middleware/auth.js', () => ({
  requireAuth: ...,
  requireAdmin: ...,
}));
```

`auth.js` also exports `issueChallenge`, `verifyChallenge` and `verifyJwt`, which `auth.routes` wires up when the app is constructed. With those exports missing from the mock, importing `src/app.js` throws:

```
[vitest] No "issueChallenge" export is defined on the "../src/middleware/auth.js" mock
```

so **all five suites fail to load** — CI reports `5 failed | 31 passed`, 146 tests run instead of 184, and the coverage step is skipped.

## Fix

Use `vi.mock` with `importOriginal` to spread the module's real exports and override only `requireAuth`/`requireAdmin`. The app loads, the middleware is still stubbed for the tests, and the suites run. (This is the pattern from #625; #703 replaced it with a comment claiming `importOriginal` was unreliable with `pool: forks`, but it runs fine here and in CI.)

Affected files:
- `backend/tests/stream.test.ts`
- `backend/tests/integration/streams.test.ts`
- `backend/tests/integration/top-up.test.ts`
- `backend/tests/integration/streams/withdraw.test.ts`
- `backend/tests/integration/streams/cancel.test.ts`

## Verification (local, against Postgres)

- `Test Files  36 passed (36)`
- `Tests  184 passed (184)`
- Coverage: 70.15% stmts / 66.73% branches / 72.34% funcs / 70.15% lines — all above the 60% gate.

Frontend and contracts jobs are unaffected (already green on this `main`).