### PR TITLE
test(frontend): add csvExport unit tests and update Vitest discovery …

### DIFF
--- a/frontend/src/components/streamCreationForm.test.tsx
+++ b/frontend/src/components/streamCreationForm.test.tsx
@@ -1,5 +1,10 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { test, expect, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}));
+
 import { StreamCreationWizard } from "./stream-creation/StreamCreationWizard";
 import React from "react";
 
@@ -16,9 +21,9 @@ test("StreamCreationWizard — validation errors shown", () => {
   );
 
   // The wizard starts at Template step. We need to go to Recipient step to test validation.
-  // Actually, let's just click 'Next' and see if it goes to next step or shows errors if any.
-  fireEvent.click(screen.getByText(/next/i));
+  // Click the Next button explicitly instead of matching incidental text.
+  fireEvent.click(screen.getByRole('button', { name: /next/i }));
 
   // It should move to Recipient step.
-  expect(screen.getByText(/recipient/i)).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: /recipient address/i })).toBeInTheDocument();
 });

--- a/frontend/src/utils/csvExport.test.ts
+++ b/frontend/src/utils/csvExport.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { convertArrayToCSV, downloadCSV, escapeCsvCell } from './csvExport';
+
+describe('escapeCsvCell', () => {
+  it('returns empty string for null', () => {
+    expect(escapeCsvCell(null)).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(escapeCsvCell(undefined)).toBe('');
+  });
+
+  it('returns plain strings unchanged', () => {
+    expect(escapeCsvCell('hello')).toBe('hello');
+  });
+
+  it('quotes values containing commas', () => {
+    expect(escapeCsvCell('hello,world')).toBe('"hello,world"');
+  });
+
+  it('quotes values containing newlines', () => {
+    expect(escapeCsvCell('hello\nworld')).toBe('"hello\nworld"');
+  });
+
+  it('doubles quotes inside values', () => {
+    expect(escapeCsvCell('She said "Hi"')).toBe('"She said ""Hi"""');
+  });
+
+  it('formats Date values via toLocaleString', () => {
+    const original = Date.prototype.toLocaleString;
+    Date.prototype.toLocaleString = function () {
+      return '2026-06-01 12:00:00';
+    };
+
+    try {
+      expect(escapeCsvCell(new Date('2026-06-01T12:00:00Z'))).toBe('2026-06-01 12:00:00');
+    } finally {
+      Date.prototype.toLocaleString = original;
+    }
+  });
+});
+
+describe('convertArrayToCSV', () => {
+  it('returns an empty string for an empty array', () => {
+    expect(convertArrayToCSV([])).toBe('');
+  });
+
+  it('serializes a single row correctly', () => {
+    const rows = [{ name: 'Alice', amount: 10 }];
+    expect(convertArrayToCSV(rows)).toBe('name,amount\nAlice,10');
+  });
+
+  it('serializes multiple rows with mixed values', () => {
+    const rows = [
+      { id: 1, value: 'hello,world' },
+      { id: 2, value: 'line\nbreak' },
+      { id: 3, value: 'quote"test' },
+    ];
+
+    expect(convertArrayToCSV(rows)).toBe(
+      'id,value\n1,"hello,world"\n2,"line\nbreak"\n3,"quote""test"'
+    );
+  });
+
+  it('preserves header order from the first row', () => {
+    const rows = [
+      { b: 1, a: 'first' },
+      { b: 2, a: 'second' },
+    ];
+
+    expect(convertArrayToCSV(rows)).toBe('b,a\n1,first\n2,second');
+  });
+});
+
+describe('downloadCSV', () => {
+  let originalURL: typeof URL;
+
+  beforeEach(() => {
+    originalURL = globalThis.URL;
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(globalThis, 'URL', {
+      configurable: true,
+      writable: true,
+      value: originalURL,
+    });
+  });
+
+  it('creates a Blob and triggers a download', () => {
+    const createObjectURL = vi.fn(() => 'blob://test-url');
+    const revokeObjectURL = vi.fn();
+
+    Object.defineProperty(globalThis, 'URL', {
+      configurable: true,
+      writable: true,
+      value: {
+        ...globalThis.URL,
+        createObjectURL,
+        revokeObjectURL,
+      } as unknown as typeof URL,
+    });
+
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    downloadCSV([{ foo: 'bar' }], 'test.csv');
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob://test-url');
+    expect(document.querySelector('a[download="test.csv"]')).toBeNull();
+  });
+});

--- a/frontend/src/utils/csvExport.ts
+++ b/frontend/src/utils/csvExport.ts
@@ -2,7 +2,7 @@
 
 type CsvRow = Record<string, unknown>;
 
-const escapeCsvCell = (value: unknown): string => {
+export const escapeCsvCell = (value: unknown): string => {
     if (value === null || value === undefined) {
         return '';
     }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     environment: 'happy-dom',
     globals: true,
     setupFiles: ['./src/__tests__/setup.ts'],
-    include: ['src/__tests__/**/*.{test,spec}.{ts,tsx}'],
+    include: ['src/__tests__/**/*.{test,spec}.{ts,tsx}', 'src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       reporter: ['text', 'json', 'html'],
       include: ['src/utils/**', 'src/hooks/**', 'src/components/**'],


### PR DESCRIPTION
# PR: Add CSV export unit tests for frontend utils (closes #692)

## Summary

This pull request adds comprehensive unit test coverage for `frontend/src/utils/csvExport.ts`, including new tests for `escapeCsvCell`, `convertArrayToCSV`, and `downloadCSV`.

## What changed

- Exported `escapeCsvCell` from `frontend/src/utils/csvExport.ts` so it can be tested directly.
- Added `frontend/src/utils/csvExport.test.ts` with Vitest tests for:
  - `escapeCsvCell` behavior for `null`, `undefined`, plain strings, values containing commas, newlines, and quotes, and `Date` values.
  - `convertArrayToCSV` behavior for an empty array, a single row, multiple rows with mixed values, and header order preservation.
  - `downloadCSV` behavior in a JSDOM environment by asserting that `URL.createObjectURL`, anchor click, and `URL.revokeObjectURL` are used appropriately.
- Updated `frontend/vitest.config.ts` test discovery to include test files under `src/**/*.{test,spec}.{ts,tsx}` in addition to `src/__tests__/**/*.{test,spec}.{ts,tsx}`.
- Fixed an existing frontend test selector in `frontend/src/components/streamCreationForm.test.tsx` to avoid incidental text collisions.

## Testing

- `cd frontend && npm test`
- Result: `95 passed`

## Files changed

- `frontend/src/utils/csvExport.ts`
- `frontend/src/utils/csvExport.test.ts`
- `frontend/vitest.config.ts`
- `frontend/src/components/streamCreationForm.test.tsx`

## Notes

This PR closes issue #692 by adding the missing unit tests for the CSV export utility and ensuring the frontend test suite remains green.
