### PR TITLE
fix(backend): add MemoryCache unit tests and fix 0 TTL expiry

### DIFF
--- a/backend/src/lib/redis.ts
+++ b/backend/src/lib/redis.ts
@@ -29,7 +29,7 @@ class MemoryCache {
       this.misses++;
       return null;
     }
-    if (Date.now() > item.expiresAt) {
+    if (Date.now() >= item.expiresAt) {
       this.cache.delete(key);
       this.misses++;
       return null;
@@ -54,6 +54,10 @@ class MemoryCache {
   getMetadata(key: string) {
     const item = this.cache.get(key);
     if (!item) return null;
+    if (Date.now() >= item.expiresAt) {
+      this.cache.delete(key);
+      return null;
+    }
     return {
       createdAt: new Date(item.createdAt).toISOString(),
       expiresAt: new Date(item.expiresAt).toISOString(),
@@ -73,7 +77,7 @@ class MemoryCache {
   cleanup(): void {
     const now = Date.now();
     for (const [key, item] of this.cache.entries()) {
-      if (now > item.expiresAt) {
+      if (now >= item.expiresAt) {
         this.cache.delete(key);
       }
     }

--- a/backend/tests/memory-cache.test.ts
+++ b/backend/tests/memory-cache.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cache } from '../src/lib/redis.js';
+
+describe('MemoryCache', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('set+get returns value', () => {
+    const key = 'memory-cache-set-get';
+    cache.set(key, 'value', 10);
+    expect(cache.get(key)).toBe('value');
+  });
+
+  it('set with 0 TTL is immediately expired', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+
+    const key = 'memory-cache-zero-ttl';
+    cache.set(key, 'value', 0);
+
+    expect(cache.get(key)).toBeNull();
+  });
+
+  it('expired entries are pruned by cleanup()', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2000);
+
+    const key = 'memory-cache-expired';
+    const initialStats = cache.getStats();
+
+    cache.set(key, 'value', 1);
+    vi.advanceTimersByTime(1500);
+    cache.cleanup();
+
+    expect(cache.get(key)).toBeNull();
+    expect(cache.getStats().itemCount).toBe(initialStats.itemCount);
+  });
+
+  it('del() removes an entry', () => {
+    const key = 'memory-cache-delete';
+    cache.set(key, 'value', 10);
+    cache.del(key);
+    expect(cache.get(key)).toBeNull();
+  });
+
+  it('getStats() reflects hits, misses, and itemCount', () => {
+    const key = 'memory-cache-stats';
+    const missingKey = 'memory-cache-stats-missing';
+    const initialStats = cache.getStats();
+
+    cache.set(key, 'value', 10);
+    cache.get(key);
+    cache.get(missingKey);
+
+    const finalStats = cache.getStats();
+    expect(finalStats.hits).toBe(initialStats.hits + 1);
+    expect(finalStats.misses).toBe(initialStats.misses + 1);
+    expect(finalStats.itemCount).toBe(initialStats.itemCount + 1);
+  });
+
+  it('getMetadata() returns ISO timestamps', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(3000);
+
+    const key = 'memory-cache-metadata';
+    cache.set(key, 'value', 10);
+
+    const metadata = cache.getMetadata(key);
+    expect(metadata).not.toBeNull();
+    expect(metadata).toEqual({
+      createdAt: new Date(3000).toISOString(),
+      expiresAt: new Date(13000).toISOString(),
+    });
+  });
+});


### PR DESCRIPTION
# Fix backend MemoryCache tests and zero-TTL expiry

## Summary

This PR adds dedicated unit tests for `backend/src/lib/redis.ts` `MemoryCache` and fixes immediate expiry behavior for zero TTL values.

## Changes

- Fix `MemoryCache.get()` and `cleanup()` so cache entries expire when `Date.now() >= expiresAt`
- Update `getMetadata()` to return `null` for expired items
- Add `backend/tests/memory-cache.test.ts` with tests for:
  - set/get returns value
  - 0 TTL entries expire immediately
  - expired entries are removed by `cleanup()`
  - `del()` removes cache entries
  - `getStats()` reports hits, misses, and itemCount
  - `getMetadata()` returns ISO timestamps

## Testing

```bash
cd backend
npx vitest run --coverage false tests/redis.test.ts tests/memory-cache.test.ts