### PR TITLE
test: add backend unit tests for indexerService getIndexerStatus/rese…

### DIFF
--- a/backend/tests/indexer-service.test.ts
+++ b/backend/tests/indexer-service.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/lib/prisma.js', () => ({
+  prisma: {
+    indexerState: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../src/workers/soroban-event-worker.js', () => ({
+  sorobanEventWorker: {
+    triggerPoll: vi.fn(),
+  },
+}));
+
+vi.mock('../src/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { prisma } from '../src/lib/prisma.js';
+import { sorobanEventWorker } from '../src/workers/soroban-event-worker.js';
+import * as indexerService from '../src/services/indexerService.js';
+
+const mockedPrisma = prisma as unknown as {
+  indexerState: {
+    findUnique: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
+  };
+};
+
+const mockedWorker = sorobanEventWorker as unknown as {
+  triggerPoll: ReturnType<typeof vi.fn>;
+};
+
+describe('Indexer Service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns lagSeconds = -1 when no state row exists', async () => {
+    mockedPrisma.indexerState.findUnique.mockResolvedValueOnce(null);
+
+    const status = await indexerService.getIndexerStatus();
+
+    expect(status.lagSeconds).toBe(-1);
+    expect(status.lastLedger).toBe(0);
+    expect(status.lastCursor).toBeNull();
+    expect(mockedPrisma.indexerState.findUnique).toHaveBeenCalledWith({
+      where: { id: 'singleton' },
+    });
+  });
+
+  it('returns lagSeconds >= 0 when a state row exists', async () => {
+    const updatedAt = new Date(Date.now() - 5_000);
+    mockedPrisma.indexerState.findUnique.mockResolvedValueOnce({
+      id: 'singleton',
+      lastLedger: 123,
+      lastCursor: 'cursor-xyz',
+      updatedAt,
+    });
+
+    const status = await indexerService.getIndexerStatus();
+
+    expect(status.lastLedger).toBe(123);
+    expect(status.lastCursor).toBe('cursor-xyz');
+    expect(status.updatedAt).toEqual(updatedAt);
+    expect(status.lagSeconds).toBeGreaterThanOrEqual(5);
+  });
+
+  it('upserts the indexer state with lastCursor null when resetIndexer is called', async () => {
+    mockedPrisma.indexerState.upsert.mockResolvedValueOnce({
+      id: 'singleton',
+      lastLedger: 0,
+      lastCursor: null,
+      updatedAt: new Date(),
+    });
+
+    await indexerService.resetIndexer(0);
+
+    expect(mockedPrisma.indexerState.upsert).toHaveBeenCalledWith({
+      where: { id: 'singleton' },
+      create: { id: 'singleton', lastLedger: 0, lastCursor: null },
+      update: { lastLedger: 0, lastCursor: null },
+    });
+  });
+
+  it('calls resetIndexer then triggerPoll when replayFromLedger is invoked', async () => {
+    mockedPrisma.indexerState.upsert.mockResolvedValueOnce({
+      id: 'singleton',
+      lastLedger: 55,
+      lastCursor: null,
+      updatedAt: new Date(),
+    });
+    mockedWorker.triggerPoll.mockResolvedValueOnce(undefined);
+
+    await indexerService.replayFromLedger(55);
+
+    expect(mockedPrisma.indexerState.upsert).toHaveBeenCalledWith({
+      where: { id: 'singleton' },
+      create: { id: 'singleton', lastLedger: 55, lastCursor: null },
+      update: { lastLedger: 55, lastCursor: null },
+    });
+    expect(mockedWorker.triggerPoll).toHaveBeenCalled();
+    expect(
+      mockedPrisma.indexerState.upsert.mock.invocationCallOrder[0]
+    ).toBeLessThan(mockedWorker.triggerPoll.mock.invocationCallOrder[0]);
+  });
+});

--- a/backend/tests/indexer-service.test.ts
+++ b/backend/tests/indexer-service.test.ts
@@ -106,8 +106,8 @@ describe('Indexer Service', () => {
       update: { lastLedger: 55, lastCursor: null },
     });
     expect(mockedWorker.triggerPoll).toHaveBeenCalled();
-    expect(
-      mockedPrisma.indexerState.upsert.mock.invocationCallOrder[0]
-    ).toBeLessThan(mockedWorker.triggerPoll.mock.invocationCallOrder[0]);
+    const upsertOrder = mockedPrisma.indexerState.upsert.mock.invocationCallOrder?.[0] ?? -1;
+    const triggerOrder = mockedWorker.triggerPoll.mock.invocationCallOrder?.[0] ?? -1;
+    expect(upsertOrder).toBeLessThan(triggerOrder);
   });
 });


### PR DESCRIPTION
# Add backend unit tests for indexerService (getIndexerStatus / resetIndexer / replayFromLedger)

## Summary

This PR adds unit tests for `backend/src/services/indexerService.ts`, covering admin-facing indexer operations that are currently missing direct service-level test coverage.

## What changed

- Added `backend/tests/indexer-service.test.ts`
- Mocked:
  - `prisma.indexerState`
  - `sorobanEventWorker.triggerPoll`
  - `logger`
- Added test coverage for:
  - `getIndexerStatus()` when the indexer state row is absent
  - `getIndexerStatus()` when the indexer state row exists
  - `resetIndexer(0)` upserting the row with `lastCursor: null`
  - `replayFromLedger()` calling reset and then `triggerPoll()`

## Testing

```bash
cd backend
npx vitest run tests/indexer-service.test.ts