### PR TITLE
test: add backend JWT unit tests for auth sign/verify happy paths

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -60,7 +60,7 @@ function b64url(buf: Buffer | string): string {
   return b.toString('base64url');
 }
 
-function signJwt(payload: object): string {
+export function signJwt(payload: object): string {
   const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
   const body = b64url(JSON.stringify(payload));
   const sig = crypto

--- a/backend/tests/auth-jwt.test.ts
+++ b/backend/tests/auth-jwt.test.ts
@@ -9,7 +9,7 @@ describe('JWT helpers', () => {
     vi.resetModules();
     vi.stubEnv('JWT_SECRET', JWT_SECRET);
 
-    const auth = await import('../src/middleware/auth.ts');
+    const auth = await import('../src/middleware/auth.js');
     signJwt = auth.signJwt;
     verifyJwt = auth.verifyJwt;
   });
@@ -24,7 +24,7 @@ describe('JWT helpers', () => {
   it('returns null for a tampered header', async () => {
     const now = Math.floor(Date.now() / 1000);
     const token = signJwt({ sub: 'GTESTPUBLICKEY123', iat: now, exp: now + 3600 });
-    const parts = token.split('.');
+    const parts = token.split('.') as [string, string, string];
     parts[0] = parts[0].slice(0, -1) + (parts[0].slice(-1) === 'A' ? 'B' : 'A');
 
     expect(verifyJwt(parts.join('.'))).toBeNull();
@@ -33,7 +33,7 @@ describe('JWT helpers', () => {
   it('returns null for a tampered body', async () => {
     const now = Math.floor(Date.now() / 1000);
     const token = signJwt({ sub: 'GTESTPUBLICKEY123', iat: now, exp: now + 3600 });
-    const parts = token.split('.');
+    const parts = token.split('.') as [string, string, string];
     parts[1] = parts[1].slice(0, -1) + (parts[1].slice(-1) === 'A' ? 'B' : 'A');
 
     expect(verifyJwt(parts.join('.'))).toBeNull();
@@ -42,7 +42,7 @@ describe('JWT helpers', () => {
   it('returns null for a tampered signature', async () => {
     const now = Math.floor(Date.now() / 1000);
     const token = signJwt({ sub: 'GTESTPUBLICKEY123', iat: now, exp: now + 3600 });
-    const parts = token.split('.');
+    const parts = token.split('.') as [string, string, string];
     parts[2] = parts[2].slice(0, -1) + (parts[2].slice(-1) === 'A' ? 'B' : 'A');
 
     expect(verifyJwt(parts.join('.'))).toBeNull();

--- a/backend/tests/auth-jwt.test.ts
+++ b/backend/tests/auth-jwt.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('JWT helpers', () => {
+  const JWT_SECRET = 'test-jwt-secret';
+  let signJwt: (payload: object) => string;
+  let verifyJwt: (token: string) => { publicKey: string } | null;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.stubEnv('JWT_SECRET', JWT_SECRET);
+
+    const auth = await import('../src/middleware/auth.ts');
+    signJwt = auth.signJwt;
+    verifyJwt = auth.verifyJwt;
+  });
+
+  it('round-trips through verifyJwt', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = signJwt({ sub: 'GTESTPUBLICKEY123', iat: now, exp: now + 3600 });
+
+    expect(verifyJwt(token)).toEqual({ publicKey: 'GTESTPUBLICKEY123' });
+  });
+
+  it('returns null for a tampered header', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = signJwt({ sub: 'GTESTPUBLICKEY123', iat: now, exp: now + 3600 });
+    const parts = token.split('.');
+    parts[0] = parts[0].slice(0, -1) + (parts[0].slice(-1) === 'A' ? 'B' : 'A');
+
+    expect(verifyJwt(parts.join('.'))).toBeNull();
+  });
+
+  it('returns null for a tampered body', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = signJwt({ sub: 'GTESTPUBLICKEY123', iat: now, exp: now + 3600 });
+    const parts = token.split('.');
+    parts[1] = parts[1].slice(0, -1) + (parts[1].slice(-1) === 'A' ? 'B' : 'A');
+
+    expect(verifyJwt(parts.join('.'))).toBeNull();
+  });
+
+  it('returns null for a tampered signature', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = signJwt({ sub: 'GTESTPUBLICKEY123', iat: now, exp: now + 3600 });
+    const parts = token.split('.');
+    parts[2] = parts[2].slice(0, -1) + (parts[2].slice(-1) === 'A' ? 'B' : 'A');
+
+    expect(verifyJwt(parts.join('.'))).toBeNull();
+  });
+
+  it('returns null for an expired token', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = signJwt({ sub: 'GTESTPUBLICKEY123', iat: now - 3600, exp: now - 1 });
+
+    expect(verifyJwt(token)).toBeNull();
+  });
+
+  it('returns null for a malformed token missing dots', async () => {
+    expect(verifyJwt('abc.def')).toBeNull();
+  });
+
+  it('returns null for an entirely fabricated string', async () => {
+    expect(verifyJwt('totally.fake.token')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Add focused backend unit tests for `backend/src/middleware/auth.ts` JWT internals.

This change exports `signJwt` and adds `backend/tests/auth-jwt.test.ts`, covering:

- valid `signJwt({ sub, iat, exp })` round-trip through `verifyJwt`
- `verifyJwt` returns `null` for:
  - tampered header
  - tampered body
  - tampered signature
  - expired token
  - malformed token with missing dots
  - entirely fabricated token string

The tests use `vi.stubEnv('JWT_SECRET', ...)` before importing the module, ensuring deterministic JWT secret behavior.

## Testing

```bash
cd backend
npx vitest run auth-jwt.test.ts --coverage=false