### PR TITLE
fix(sse): update stream payload type in map function

### DIFF
--- a/backend/src/controllers/sse.controller.ts
+++ b/backend/src/controllers/sse.controller.ts
@@ -49,7 +49,7 @@ export const subscribe = async (req: Request, res: Response) => {
       where: { OR: [{ sender: publicKey }, { recipient: publicKey }] },
       select: { streamId: true },
     });
-    const ownedIds = new Set(ownedStreams.map((s: any) => String(s.streamId)));
+    const ownedIds = new Set(ownedStreams.map((s: { streamId: number }) => String(s.streamId)));
 
     let subscriptions: string[];
     if (all) {


### PR DESCRIPTION
Fixes #637.

This PR replaces (s: any) with (s: { streamId: number }) in the SSE controller. The catch (error: any) block was already addressed by a previous PR (#708).