### PR TITLE
docs: remove broken discussion category links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,11 +269,8 @@ If you discover a security vulnerability, please see our [Security Policy](SECUR
 
 ## Community & Support
 
-Have questions? Want to share ideas or projects? Join the conversation!
+Review the discussions guide before opening an issue or looking for community support.
 
-- **❓ [Ask Questions](https://github.com/flowfi/flowfi/discussions/categories/q-a)** - Get help in GitHub Discussions Q&A
-- **💡 [Share Ideas](https://github.com/flowfi/flowfi/discussions/categories/ideas)** - Propose features and discuss improvements
-- **🎪 [Show and Tell](https://github.com/flowfi/flowfi/discussions/categories/show-and-tell)** - Share projects and use cases built with FlowFi
 - **📖 [Discussions Guide](DISCUSSIONS.md)** - Learn when to use Discussions vs Issues.
 
 ## Contributors


### PR DESCRIPTION
## Description
Remove the broken GitHub Discussions category links from the README community section.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update

## Related Issues
Closes #618

## Changes Made
- removed the three GitHub Discussions category links from `README.md`
- updated the intro copy so the section still points readers to `DISCUSSIONS.md`
- verified that GitHub Discussions are currently disabled for `LabsCrypt/flowfi`, so the category URLs should not be linked right now

## Testing
### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Steps
1. Confirmed `gh repo view LabsCrypt/flowfi --json hasDiscussionsEnabled` returns `false`.
2. Checked the three `LabsCrypt/flowfi` category URLs and confirmed each returns HTTP `404`.
3. Ran `git diff --check` to verify the README edit is clean.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have checked for breaking changes and documented them if applicable

## Additional Notes
This PR stays within the issue scope by updating only `README.md`.
