### PR TITLE
Fix/pagination magic numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 _Programmable, real-time payment streams and recurring subscriptions._
 
+i just need to create a draft pr
+
 ## Overview
 
 FlowFi allows users to create continuous payment streams and recurring subscriptions using stablecoins on the Stellar network. By leveraging Soroban smart contracts, FlowFi enables autonomous accurate-to-the-second distribution of funds.

--- a/backend/src/controllers/stream.controller.ts
+++ b/backend/src/controllers/stream.controller.ts
@@ -12,6 +12,10 @@ import {
   resumeStream as sorobanResumeStream,
 } from '../services/sorobanService.js';
 import type { AuthenticatedRequest } from '../types/auth.types.js';
+import { DEFAULT_EVENTS_PAGE_SIZE, MAX_EVENTS_PAGE_SIZE } from '../routes/v1/events.routes.js';
+
+const DEFAULT_STREAM_PAGE_SIZE = 20;
+const MAX_STREAM_PAGE_SIZE = 100;
 
 interface UserStreamSummary {
   address: string;
@@ -170,8 +174,8 @@ export const listStreams = async (req: Request, res: Response) => {
 
     // Validate and parse pagination parameters
     const parsedLimit = Math.min(
-      typeof limit === 'string' ? (Number.parseInt(limit, 10) || 20) : 20,
-      100
+      typeof limit === 'string' ? (Number.parseInt(limit, 10) || DEFAULT_STREAM_PAGE_SIZE) : DEFAULT_STREAM_PAGE_SIZE,
+      MAX_STREAM_PAGE_SIZE
     );
     const parsedOffset = typeof offset === 'string' ? (Number.parseInt(offset, 10) || 0) : 0;
 
@@ -285,8 +289,8 @@ export const getStreamEvents = async (req: Request, res: Response) => {
     const eventType = typeof req.query['eventType'] === 'string' ? req.query['eventType'] : undefined;
 
     const limit = Math.min(
-      rawLimit && typeof rawLimit === 'string' ? (Number.parseInt(rawLimit, 10) || 50) : 50,
-      500,
+      rawLimit && typeof rawLimit === 'string' ? (Number.parseInt(rawLimit, 10) || DEFAULT_EVENTS_PAGE_SIZE) : DEFAULT_EVENTS_PAGE_SIZE,
+      MAX_EVENTS_PAGE_SIZE,
     );
 
     let offset = 0;

--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -3,6 +3,7 @@ import { prisma } from '../lib/prisma.js';
 import logger from '../logger.js';
 import { registerUserSchema } from '../validators/user.validator.js';
 import type { AuthenticatedRequest } from '../types/auth.types.js';
+import { DEFAULT_EVENTS_PAGE_SIZE, MAX_EVENTS_PAGE_SIZE } from '../routes/v1/events.routes.js';
 
 /**
  * Register a new wallet public key
@@ -81,8 +82,8 @@ export const getUserEvents = async (req: Request, res: Response, next: NextFunct
         const rawOffset = req.query['offset'];
 
         const limit = Math.min(
-            rawLimit && typeof rawLimit === 'string' ? (Number.parseInt(rawLimit, 10) || 50) : 50,
-            200
+            rawLimit && typeof rawLimit === 'string' ? (Number.parseInt(rawLimit, 10) || DEFAULT_EVENTS_PAGE_SIZE) : DEFAULT_EVENTS_PAGE_SIZE,
+            MAX_EVENTS_PAGE_SIZE
         );
         const offset = rawOffset && typeof rawOffset === 'string' ? (Number.parseInt(rawOffset, 10) || 0) : 0;
 

--- a/backend/src/routes/v1/events.routes.ts
+++ b/backend/src/routes/v1/events.routes.ts
@@ -21,8 +21,8 @@ const EVENT_TYPES = new Set([
   'ADMIN_TRANSFERRED',
 ]);
 
-const MAX_EVENT_LIMIT = 200;
-const DEFAULT_EVENT_LIMIT = 50;
+export const MAX_EVENTS_PAGE_SIZE = 200;
+export const DEFAULT_EVENTS_PAGE_SIZE = 50;
 
 /**
  * @openapi
@@ -86,8 +86,8 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
 
     const parsedLimit = Number.parseInt(String(req.query.limit ?? ''), 10);
     const limit = Number.isFinite(parsedLimit) && parsedLimit > 0
-      ? Math.min(parsedLimit, MAX_EVENT_LIMIT)
-      : DEFAULT_EVENT_LIMIT;
+      ? Math.min(parsedLimit, MAX_EVENTS_PAGE_SIZE)
+      : DEFAULT_EVENTS_PAGE_SIZE;
 
     const hasOffset = req.query.offset !== undefined;
     const parsedOffset = Number.parseInt(String(req.query.offset ?? ''), 10);


### PR DESCRIPTION
### Description
This PR resolves the issue with pagination magic numbers scattered across stream and user controllers, bringing consistency and clarity to the pagination limits across the codebase.

closes #669

### Changes Made
- Exported existing `DEFAULT_EVENTS_PAGE_SIZE` and `MAX_EVENTS_PAGE_SIZE` (previously `DEFAULT_EVENT_LIMIT` and `MAX_EVENT_LIMIT`) from `routes/v1/events.routes.ts` to be reused across controllers.
- Defined module-scoped `DEFAULT_STREAM_PAGE_SIZE` (20) and `MAX_STREAM_PAGE_SIZE` (100) inside `stream.controller.ts` for stream listings.
- Replaced the inline magic numbers in the `getStreamEvents` method (in `stream.controller.ts`) and the `getUserEvents` method (in `user.controller.ts`) with the imported `DEFAULT_EVENTS_PAGE_SIZE` (50) and `MAX_EVENTS_PAGE_SIZE` (200) constants.

### Files Touched
- `backend/src/routes/v1/events.routes.ts`
- `backend/src/controllers/stream.controller.ts`
- `backend/src/controllers/user.controller.ts`

### Motivation & Context
Resolves [issue link/reference].
By centralizing the pagination constants and reusing the events pagination limits, we ensure that API lists maintain a uniform standard and we eliminate undocumented caps (such as the previous arbitrary 500 cap in `stream.controller.ts`).