### PR TITLE
Add event styles for Fee Config and Admin Transfer

### DIFF
--- a/frontend/src/app/streams/[id]/page.tsx
+++ b/frontend/src/app/streams/[id]/page.tsx
@@ -63,6 +63,8 @@ const EVENT_STYLES: Record<string, { color: string; icon: string; label: string 
   PAUSED: { color: "#f59e0b", icon: "⏸", label: "Paused" },
   RESUMED: { color: "#06b6d4", icon: "▶", label: "Resumed" },
   FEE_COLLECTED: { color: "#6b7280", icon: "$", label: "Fee" },
+  FEE_CONFIG_UPDATED: { color: "#475569", icon: "⚙", label: "Fee Config" },
+  ADMIN_TRANSFERRED: { color: "#475569", icon: "👤", label: "Admin Transfer" },
 };
 
 export default function StreamDetailsPage() {


### PR DESCRIPTION
Adds FEE_CONFIG_UPDATED and ADMIN_TRANSFERRED entries to the EVENT_STYLES map in the stream detail page, completing coverage for all 10 event types now emitted by the backend. Previously, these two events would fall through to the default grey placeholder style; they now render with a slate color, a gear icon (⚙) for fee config changes, and a person icon (👤) for admin transfers — no layout changes.
closes #656 