### PR TITLE
refactor(frontend): centralize logging and forbid console usage

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -5,6 +5,18 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    files: ["src/**/*.{js,jsx,ts,tsx}"],
+    rules: {
+      "no-console": "error",
+    },
+  },
+  {
+    files: ["src/lib/logger.ts"],
+    rules: {
+      "no-console": "off",
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/frontend/src/app/activity/page.tsx
+++ b/frontend/src/app/activity/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/Button";
 import { Loader2, Download } from "lucide-react";
 import { formatAmount } from "@/lib/amount";
 import { downloadCSV } from "@/utils/csvExport";
+import { logger } from "@/lib/logger";
 
 const PAGE_SIZE = 10;
 const API_BASE_URL = (
@@ -63,7 +64,7 @@ export default function ActivityPage() {
         }
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") return;
-        console.error("Failed to fetch activity:", error);
+        logger.error("Failed to fetch activity:", error);
         if (!append) setEvents([]);
         setHasMore(false);
       } finally {

--- a/frontend/src/app/streams/[id]/page.tsx
+++ b/frontend/src/app/streams/[id]/page.tsx
@@ -21,6 +21,7 @@ import { CancelConfirmModal } from "@/components/stream-creation/CancelConfirmMo
 import type { BackendStreamEvent } from "@/lib/api-types";
 import { formatAmount, streamProgressPercent } from "@/utils/amount";
 import { shortenPublicKey } from "@/lib/wallet";
+import { logger } from "@/lib/logger";
 
 interface StreamDetail {
   id: string;
@@ -126,7 +127,7 @@ export default function StreamDetailsPage() {
       }
     } catch (err) {
       if (err instanceof Error && err.name === "AbortError") return;
-      console.error("Failed to fetch events:", err);
+      logger.error("Failed to fetch events:", err);
     }
   }, [streamId]);
 

--- a/frontend/src/app/streams/create/page.tsx
+++ b/frontend/src/app/streams/create/page.tsx
@@ -15,6 +15,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { useWallet } from "@/context/wallet-context";
+import { logger } from "@/lib/logger";
 
 const TOKEN_DECIMALS = 7;
 
@@ -69,7 +70,7 @@ export default function CreateStreamPage() {
         }, 2000);
       }
     } catch (error) {
-      console.error("Stream creation failed:", error);
+      logger.error("Stream creation failed:", error);
       toast.error(toSorobanErrorMessage(error));
     } finally {
       setLoading(false);
@@ -187,7 +188,7 @@ export default function CreateStreamPage() {
             <div className="flex justify-between items-center text-sm">
               <span className="text-slate-400">Streaming Rate</span>
               <span className="font-mono font-medium text-accent">
-                {formData.amount && formData.duration 
+                {formData.amount && formData.duration
                   ? (Number(formData.amount) / (Number(formData.duration) * 86400)).toFixed(8)
                   : "0.00000000"} {formData.token}/sec
               </span>
@@ -207,7 +208,7 @@ export default function CreateStreamPage() {
           >
             {getButtonText()}
           </button>
-          
+
           {status !== "connected" && (
             <p className="text-center text-sm text-red-400">
               Please connect your wallet to create a stream.

--- a/frontend/src/components/TransactionTracker.tsx
+++ b/frontend/src/components/TransactionTracker.tsx
@@ -5,6 +5,7 @@ import { Loader2, CheckCircle, XCircle, ExternalLink, RefreshCw, Clock, Ban, Fil
 import toast from "react-hot-toast";
 import type { BackendStream } from "@/lib/api-types";
 import { formatAmount } from "@/utils/amount";
+import { logger } from "@/lib/logger";
 
 /**
  * TransactionTracker - Shared component for tracking on-chain transaction lifecycle
@@ -94,7 +95,7 @@ export default function TransactionTracker({
         .then(data => {
           if (data) setPreviousStreamData(data);
         })
-        .catch(console.error);
+        .catch((error) => logger.error(error));
     }
   }, [status, streamId, previousStreamData]);
 
@@ -132,7 +133,7 @@ export default function TransactionTracker({
         }
       } catch (err) {
         if (!cancelled) {
-          console.error("Polling error:", err);
+          logger.error("Polling error:", err);
         }
       }
 

--- a/frontend/src/components/stream-creation/StreamCreationWizard.tsx
+++ b/frontend/src/components/stream-creation/StreamCreationWizard.tsx
@@ -14,6 +14,7 @@ import { isValidStellarPublicKey } from "@/lib/stellar";
 import { TransactionTracker } from "../ui/TransactionTracker";
 import toast from "react-hot-toast";
 import { useRouter } from "next/navigation";
+import { logger } from "@/lib/logger";
 
 export interface StreamFormData {
   recipient: string;
@@ -110,12 +111,12 @@ export const StreamCreationWizard: React.FC<StreamCreationWizardProps> = ({
     descriptionTag: "salary",
   });
   const [errors, setErrors] = useState<Partial<Record<keyof StreamFormData, string>>>({});
-  
+
   // Tracking & Polling state (Issue #378)
   const [txHash, setTxHash] = useState<string | null>(null);
   const [isPolling, setIsPolling] = useState(false);
   const [timeoutError, setTimeoutError] = useState(false);
-  
+
   const router = useRouter();
 
   const dialogRef = useModalDialog({ onClose });
@@ -352,7 +353,7 @@ export const StreamCreationWizard: React.FC<StreamCreationWizardProps> = ({
       try {
         const response = await fetch(`/v1/streams?sender=${senderAddress}`);
         const streams = await response.json();
-        
+
         // Assuming the latest stream is what we want
         if (streams && streams.length > 0) {
           // Found!
@@ -362,7 +363,7 @@ export const StreamCreationWizard: React.FC<StreamCreationWizardProps> = ({
           return;
         }
       } catch (e) {
-        console.warn("Polling error:", e);
+        logger.warn("Polling error:", e);
       }
       await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL));
     }
@@ -379,13 +380,13 @@ export const StreamCreationWizard: React.FC<StreamCreationWizardProps> = ({
         const result = (await onSubmit(formData)) as unknown as { txHash: string };
         const hash = result?.txHash;
         setTxHash(hash);
-        
+
         // Step 2: Start Polling for Indexer
         setIsPolling(true);
         await startPolling(formData.recipient);
-        
+
       } catch (error) {
-        console.error("Failed to create stream:", error);
+        logger.error("Failed to create stream:", error);
         setIsSubmitting(false);
       }
     } else {
@@ -462,7 +463,7 @@ export const StreamCreationWizard: React.FC<StreamCreationWizardProps> = ({
   };
 
   return (
-    <div 
+    <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
@@ -510,10 +511,10 @@ export const StreamCreationWizard: React.FC<StreamCreationWizardProps> = ({
               <h3 className="text-xl font-bold mb-8">
                 {timeoutError ? "Confirmation Timeout" : "Waiting for confirmation..."}
               </h3>
-              
+
               {!timeoutError ? (
                 <>
-                  <TransactionTracker 
+                  <TransactionTracker
                     steps={[
                       { id: "1", label: "Sign Transaction", status: "completed" },
                       { id: "2", label: "Network Confirmation", status: "completed" },
@@ -540,7 +541,7 @@ export const StreamCreationWizard: React.FC<StreamCreationWizardProps> = ({
                   <div className="flex flex-col gap-4 items-center">
                     <p className="text-sm text-slate-300">Transaction Hash:</p>
                     <code className="text-xs p-2 bg-slate-800 rounded break-all max-w-xs">{txHash}</code>
-                    <a 
+                    <a
                       href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
                       target="_blank"
                       rel="noopener noreferrer"
@@ -552,8 +553,8 @@ export const StreamCreationWizard: React.FC<StreamCreationWizardProps> = ({
                       </svg>
                     </a>
                   </div>
-                  <Button 
-                    variant="outline" 
+                  <Button
+                    variant="outline"
                     className="mt-8"
                     onClick={onClose}
                   >

--- a/frontend/src/lib/dashboard.ts
+++ b/frontend/src/lib/dashboard.ts
@@ -1,5 +1,6 @@
 import type { BackendStream } from "./api-types";
 import { getStreamsEndpointCandidates, toTokenAmount } from "./api/_shared";
+import { logger } from "./logger";
 import { TOKEN_ADDRESSES } from "./soroban";
 
 export interface ActivityItem {
@@ -194,7 +195,7 @@ export async function fetchDashboardData(publicKey: string): Promise<DashboardSn
       incomingStreams,
     };
   } catch (error) {
-    console.error("Dashboard data fetch error:", error);
+    logger.error("Dashboard data fetch error:", error);
     throw error;
   }
 }

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -1,0 +1,25 @@
+const isDevelopment = process.env.NODE_ENV !== "production";
+
+export const logger = {
+  debug: (...args: unknown[]) => {
+    if (isDevelopment) {
+      console.debug(...args);
+    }
+  },
+
+  info: (...args: unknown[]) => {
+    if (isDevelopment) {
+      console.info(...args);
+    }
+  },
+
+  warn: (...args: unknown[]) => {
+    if (isDevelopment) {
+      console.warn(...args);
+    }
+  },
+
+  error: (...args: unknown[]) => {
+    console.error(...args);
+  },
+};

--- a/frontend/src/lib/soroban.ts
+++ b/frontend/src/lib/soroban.ts
@@ -1,4 +1,5 @@
 import type { WalletSession } from "@/lib/wallet";
+import { logger } from "./logger";
 
 const CONTRACT_ID =
   process.env.NEXT_PUBLIC_STREAM_CONTRACT_ID ?? "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4";
@@ -182,7 +183,7 @@ function mockTxHash(): string {
 }
 
 async function mockCall(label: string): Promise<SorobanResult> {
-  console.info(`[soroban:mock] ${label}`);
+  logger.info(`[soroban:mock] ${label}`);
   await wait(MOCK_DELAY_MS);
   return { success: true, txHash: mockTxHash() };
 }

--- a/frontend/src/utils/amount.ts
+++ b/frontend/src/utils/amount.ts
@@ -1,3 +1,5 @@
+import { logger } from "@/lib/logger";
+
 /**
  * Convert raw on-chain amount (smallest unit) to human-readable string
  * @param raw - Raw amount as bigint (i128 from chain)
@@ -266,7 +268,7 @@ export async function fetchTokenDecimals(tokenAddress: string): Promise<number> 
     const simResult = await server.simulateTransaction(tx);
 
     if (rpc.Api?.isSimulationError?.(simResult) ?? simResult?.error) {
-      console.warn(`Failed to fetch decimals for ${tokenAddress}:`, simResult.error);
+      logger.warn(`Failed to fetch decimals for ${tokenAddress}:`, simResult.error);
       // Cache default to avoid repeated failed calls
       setCachedTokenDecimals(tokenAddress, 7);
       return 7;
@@ -274,7 +276,7 @@ export async function fetchTokenDecimals(tokenAddress: string): Promise<number> 
 
     const rawResult = simResult?.result?.retval;
     if (!rawResult) {
-      console.warn(`No decimals returned for ${tokenAddress}`);
+      logger.warn(`No decimals returned for ${tokenAddress}`);
       setCachedTokenDecimals(tokenAddress, 7);
       return 7;
     }
@@ -296,7 +298,7 @@ export async function fetchTokenDecimals(tokenAddress: string): Promise<number> 
     setCachedTokenDecimals(tokenAddress, decimals);
     return decimals;
   } catch (error) {
-    console.error(`Error fetching token decimals for ${tokenAddress}:`, error);
+    logger.error(`Error fetching token decimals for ${tokenAddress}:`, error);
     // Cache default to avoid repeated failed calls
     setCachedTokenDecimals(tokenAddress, 7);
     return 7;


### PR DESCRIPTION
## Description

Centralize frontend logging behind a dedicated logger utility, replace direct `console.*` usage across the frontend, and enforce the pattern through ESLint.

## Type of Change

* [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New feature (non-breaking change which adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] 📚 Documentation update
* [x] 🔧 Refactoring (no functional changes)
* [ ] ⚡ Performance improvement
* [ ] 🧪 Test addition or update

## Related Issues

Closes #628 

## Changes Made

* Added `frontend/src/lib/logger.ts` as a centralized logging utility
* Replaced direct `console.error`, `console.warn`, and `console.info` calls with logger helpers
* Updated frontend modules to use the shared logger
* Added ESLint enforcement to forbid raw `console.*` usage outside the logger module
* Cleaned up additional console usages found in `src/utils/amount.ts`

## Testing

### Test Coverage

* [ ] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] Manual testing performed

### Test Steps

1. Run `npm run lint`
2. Verify lint passes with current changes
3. Add a temporary `console.log(...)` statement in a frontend source file
4. Run `npm run lint` and verify the `no-console` rule is triggered
5. Remove the temporary statement and verify lint passes again

## Breaking Changes

**Breaking Changes:**

* None

**Migration Guide:**

* No migration required

## Screenshots/Demo

N/A

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published
* [x] I have checked for breaking changes and documented them if applicable

## Additional Notes

* Existing test failures in `src/components/stream-creation/__tests__/template-storage.test.ts` appear to be unrelated to this change and are caused by a pre-existing `localStorage.clear is not a function` error.
* Logging behavior is now centralized, making future changes to frontend logging easier to manage.
