### PR TITLE
refactor(worker): replace transaction any types

### DIFF
--- a/backend/src/workers/soroban-event-worker.ts
+++ b/backend/src/workers/soroban-event-worker.ts
@@ -1,4 +1,5 @@
 import { rpc, xdr, StrKey } from '@stellar/stellar-sdk';
+import { Prisma } from '../generated/prisma/index.js';
 import { prisma } from '../lib/prisma.js';
 import { INDEXER_STATE_ID } from '../lib/indexer-state.js';
 import { sseService } from '../services/sse.service.js';
@@ -145,7 +146,7 @@ export class SorobanEventWorker {
     this.pollTimer = setTimeout(() => this.poll(), this.pollIntervalMs);
   }
 
-  private async ensureSystemStream(tx: any): Promise<void> {
+  private async ensureSystemStream(tx: Prisma.TransactionClient): Promise<void> {
     const systemUser = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
     await tx.user.upsert({
       where: { publicKey: systemUser },
@@ -350,7 +351,7 @@ export class SorobanEventWorker {
     const newFeeRateBps = decodeU32(body['new_fee_rate_bps']);
     const timestamp = Math.floor(Date.now() / 1000);
 
-    await prisma.$transaction(async (tx: any) => {
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       await this.ensureSystemStream(tx);
 
       await tx.streamEvent.upsert({
@@ -398,7 +399,7 @@ export class SorobanEventWorker {
     const newAdmin = decodeAddress(body['new_admin']);
     const timestamp = Math.floor(Date.now() / 1000);
 
-    await prisma.$transaction(async (tx: any) => {
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       await this.ensureSystemStream(tx);
 
       await tx.streamEvent.upsert({
@@ -461,7 +462,7 @@ export class SorobanEventWorker {
         ? null
         : startTime + Number(BigInt(depositedAmount) / ratePerSecondBigInt);
 
-    await prisma.$transaction(async (tx: any) => {
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       await tx.user.upsert({
         where: { publicKey: sender },
         create: { publicKey: sender },
@@ -550,12 +551,12 @@ export class SorobanEventWorker {
     const newDepositedAmount = decodeI128(body['new_deposited_amount']);
     const timestamp = Math.floor(Date.now() / 1000);
 
-    await prisma.$transaction(async (tx: any) => {
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const stream = await tx.stream.findUniqueOrThrow({
         where: { streamId },
         select: { ratePerSecond: true, startTime: true, totalPausedDuration: true }
       });
-      
+
       const ratePerSecondBigInt = BigInt(stream.ratePerSecond);
       const newEndTime =
         ratePerSecondBigInt === 0n
@@ -621,7 +622,7 @@ export class SorobanEventWorker {
     const amount = decodeI128(body['amount']);
     const timestamp = Number(decodeU64(body['timestamp']));
 
-    await prisma.$transaction(async (tx: any) => {
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const stream = await tx.stream.findUniqueOrThrow({
         where: { streamId },
         select: { withdrawnAmount: true },
@@ -687,7 +688,7 @@ export class SorobanEventWorker {
     const refundedAmount = decodeI128(body['refunded_amount']);
     const timestamp = Math.floor(Date.now() / 1000);
 
-    await prisma.$transaction(async (tx: any) => {
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       await tx.stream.update({
         where: { streamId },
         data: {
@@ -745,7 +746,7 @@ export class SorobanEventWorker {
     const totalWithdrawn = decodeI128(body['total_withdrawn']);
     const timestamp = Math.floor(Date.now() / 1000);
 
-    await prisma.$transaction(async (tx: any) => {
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       await tx.stream.update({
         where: { streamId },
         data: {
@@ -852,7 +853,7 @@ export class SorobanEventWorker {
     const pausedAt = Number(decodeU64(body['paused_at']));
     const timestamp = Math.floor(Date.now() / 1000);
 
-    await prisma.$transaction(async (tx: any) => {
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       await tx.stream.update({
         where: { streamId },
         data: {
@@ -909,7 +910,7 @@ export class SorobanEventWorker {
     const newEndTime = Number(decodeU64(body['new_end_time']));
     const timestamp = Math.floor(Date.now() / 1000);
 
-    await prisma.$transaction(async (tx: any) => {
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       // Get current stream to calculate paused duration
       const currentStream = await tx.stream.findUniqueOrThrow({
         where: { streamId },


### PR DESCRIPTION
## Description

Replace `any` transaction client types in the Soroban event worker with Prisma's generated `TransactionClient` type to improve compile-time type safety.

## Type of Change

* [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New feature (non-breaking change which adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] 📚 Documentation update
* [x] 🔧 Refactoring (no functional changes)
* [ ] ⚡ Performance improvement
* [ ] 🧪 Test addition or update

## Related Issues

Closes #633 

## Changes Made

* Added Prisma type imports from the generated Prisma client
* Replaced `tx: any` with `tx: Prisma.TransactionClient` in `ensureSystemStream`
* Replaced `tx: any` with `tx: Prisma.TransactionClient` in all Prisma transaction callbacks
* Enabled stronger compile-time validation for transaction-scoped Prisma operations

## Testing

### Test Coverage

* [ ] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] Manual testing performed

### Test Steps

1. Run `npm run build`
2. Verify TypeScript compilation succeeds
3. Confirm all transaction callbacks compile successfully with `Prisma.TransactionClient`

## Breaking Changes

**Breaking Changes:**

* None

**Migration Guide:**

* No migration required

## Screenshots/Demo

N/A

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published
* [x] I have checked for breaking changes and documented them if applicable

## Additional Notes

* This is a type-safety refactor only and does not change runtime behavior.
* Using `Prisma.TransactionClient` allows TypeScript to validate transaction-scoped Prisma operations and catch typos or invalid model access during compilation.
