### PR TITLE
fix(ci): point Dependabot npm at the workspace root only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,34 +2,14 @@ version: 2
 
 updates:
   # ── npm: root workspace ────────────────────────────────────────────────────
+  # flowfi is a single npm workspace (frontend + backend hoisted into one root
+  # package-lock.json). Dependabot must update from the workspace root so the
+  # root lockfile CI runs `npm ci` against stays in sync. Per-directory entries
+  # for /frontend and /backend only touched their package.json without updating
+  # the root lockfile, so every PR they opened failed `npm ci` with
+  # "lock file's X does not satisfy Y". One root entry covers all workspaces.
   - package-ecosystem: "npm"
     directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 10
-    groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
-
-  # ── npm: frontend ──────────────────────────────────────────────────────────
-  - package-ecosystem: "npm"
-    directory: "/frontend"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 10
-    groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
-
-  # ── npm: backend ───────────────────────────────────────────────────────────
-  - package-ecosystem: "npm"
-    directory: "/backend"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Why

flowfi is a single npm **workspace** (frontend + backend hoisted into one root `package-lock.json`). `dependabot.yml` declared separate npm ecosystems for `/frontend` and `/backend`, but those entries only bump the directory's `package.json` without updating the root lockfile that CI runs `npm ci` against.

Result: every Dependabot PR from those two entries dies at install:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync
npm error Invalid: lock file's next@16.2.7 does not satisfy next@16.2.9
```

That is exactly why PRs #764-#770 are all red on Backend CI / Frontend CI / Backend npm test / Vuln Scan, while the grouped root PR (#771) passed and merged cleanly.

## Fix

Drop the redundant `/frontend` and `/backend` npm entries. The root `/` npm entry already covers the whole workspace and updates the root lockfile, so future Dependabot PRs will install cleanly. Cargo and github-actions entries are unchanged.

## Follow-up (separate)

The currently-open PRs #764-#770 were generated by the now-removed entries and cannot pass as-is; they should be closed (Dependabot will re-propose the relevant bumps from the root entry on the next run). #763 (soroban-sdk 22 -> 26) is a real major Rust bump that needs a contracts migration, not a lockfile fix.