### PR TITLE
Fix/doc updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,3 @@
----
 # Contributing to FlowFi
 
 Thank you for your interest in contributing to **FlowFi**
@@ -6,15 +5,14 @@ Thank you for your interest in contributing to **FlowFi**
 FlowFi is a DeFi payment streaming protocol built on Stellar using Soroban smart contracts. This guide explains how to set up your local development environment and contribute effectively.
 
 Please read this document carefully before opening a Pull Request.
----
 
 ## Getting Help & Asking Questions
 
 Have questions before contributing? We've got you covered!
 
-- **Questions about using FlowFi?** → Start a discussion in [GitHub Discussions - Q&A](https://github.com/flowfi/flowfi/discussions/categories/q-a)
-- **Found a bug?** → [Open an Issue](https://github.com/flowfi/flowfi/issues)
-- **Want to suggest a feature?** → [Start a Discussion - Ideas](https://github.com/flowfi/flowfi/discussions/categories/ideas)
+- **Questions about using FlowFi?** → Start a discussion in [GitHub Discussions - Q&A](https://github.com/LabsCrypt/flowfi/discussions/categories/q-a)
+- **Found a bug?** → [Open an Issue](https://github.com/LabsCrypt/flowfi/issues)
+- **Want to suggest a feature?** → [Start a Discussion - Ideas](https://github.com/LabsCrypt/flowfi/discussions/categories/ideas)
 - **Need help setting up?** → Check [Local Development Setup](#local-development-setup) or ask in Discussions
 
 ### Issues vs Discussions
@@ -106,7 +104,7 @@ docker compose up --build
 
 This starts:
 
-- PostgreSQL (port 5432)
+- PostgreSQL (port 5433)
 - Backend API (port 3001)
 
 To run in detached mode:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 _Programmable, real-time payment streams and recurring subscriptions._
 
-i just need to create a draft pr
-
 ## Overview
 
 FlowFi allows users to create continuous payment streams and recurring subscriptions using stablecoins on the Stellar network. By leveraging Soroban smart contracts, FlowFi enables autonomous accurate-to-the-second distribution of funds.
@@ -197,6 +195,7 @@ stellar contract invoke --id CONTRACT_ID --source YOUR_SECRET_KEY --network http
 
 The FlowFi backend API uses URL-based versioning. All endpoints are prefixed with a version (e.g., `/v1/streams`).
 
+- **Authentication**: [backend/docs/AUTHENTICATION.md](backend/docs/AUTHENTICATION.md)
 - **API Versioning Guide**: [backend/docs/API_VERSIONING.md](backend/docs/API_VERSIONING.md)
 - **Deprecation Policy**: [backend/docs/DEPRECATION_POLICY.md](backend/docs/DEPRECATION_POLICY.md)
 - **Sandbox Mode**: [backend/docs/SANDBOX_MODE.md](backend/docs/SANDBOX_MODE.md) - Test without affecting production data

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,37 @@
+# FlowFi Backend
+
+This is the Node.js / Express backend for FlowFi. It provides the REST API for the frontend, indexes on-chain events from the Stellar network, and serves real-time updates via Server-Sent Events (SSE).
+
+## Scripts
+
+- `npm install`: Installs dependencies.
+- `npm run dev`: Starts the development server using nodemon.
+- `npm run build`: Compiles TypeScript to JavaScript.
+- `npm start`: Runs the compiled server.
+- `npm run db:push`: Pushes Prisma schema changes to the database.
+
+## Environment Variables
+
+Create a `.env` file with the following variables:
+
+```env
+DATABASE_URL=postgresql://user:password@localhost:5433/flowfi?schema=public
+PORT=3001
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+```
+
+## Prisma Database
+
+We use Prisma as our ORM to interact with PostgreSQL.
+
+- Schema is located at `prisma/schema.prisma`.
+- Run `npx prisma studio` to view the database through a web UI.
+
+## /v1 API
+
+All REST API endpoints are prefixed with `/v1`. Refer to the API Documentation in the root `README.md` and the `docs/` folder for versioning and authentication details.
+
+## Server-Sent Events (SSE)
+
+The backend exposes an SSE endpoint (`/v1/streams/events`) to stream real-time updates to the frontend whenever on-chain stream events are indexed.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,27 @@
+# FlowFi Contracts
+
+This directory contains the Soroban smart contracts for FlowFi.
+
+## Layout
+
+- `stream_contract/`: Contains the core streaming logic, including stream creation, funding, claiming, and cancellation.
+
+## Building & Testing
+
+To build the contracts for testing and validation:
+
+```bash
+cargo build
+cargo test
+```
+
+## WASM Target
+
+To compile the contract to the `wasm32-unknown-unknown` target for Soroban deployment:
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+stellar contract optimize --wasm target/wasm32-unknown-unknown/release/stream_contract.wasm
+```
+
+The optimized WASM file will be available at `target/wasm32-unknown-unknown/release/stream_contract.optimized.wasm`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,6 +103,8 @@ Rules used by backend/domain logic:
 
 ## Authentication Flow
 
+See [Authentication Documentation](../backend/docs/AUTHENTICATION.md) for full details.
+
 ```mermaid
 sequenceDiagram
     participant U as User Wallet (Freighter)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,31 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# FlowFi Frontend
 
-## Getting Started
+This is the Next.js frontend for FlowFi, providing the user interface for creating and managing continuous payment streams and recurring subscriptions.
 
-First, run the development server:
+## Purpose
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+The frontend connects to the FlowFi backend API and interacts with the Freighter wallet to allow users to sign transactions and manage their streams.
+
+## Layout
+
+- `src/app/`: Next.js App Router pages and layouts.
+- `src/components/`: Reusable React components.
+- `src/hooks/`: Custom React hooks for API and wallet integration.
+- `src/lib/`: Utility functions and shared logic.
+
+## Environment Variables
+
+Create a `.env.local` file with the following variables:
+
+```env
+NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+NEXT_PUBLIC_RPC_URL=https://soroban-testnet.stellar.org
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Scripts
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- `npm run dev`: Starts the development server.
+- `npm run build`: Builds the app for production.
+- `npm start`: Runs the production server.
+- `npm run lint`: Runs ESLint to check for code issues.


### PR DESCRIPTION
closes #899 
closes #902 
closes #906 
closes #907 

## Description

This PR resolves four documentation issues across the repository:
1. **Root README Cleanup**: Removed the leftover editor note ("i just need to create a draft pr") from the root `README.md` to ensure the header and Overview section read cleanly.
2. **Package-Specific READMEs**: Replaced the boilerplate Next.js README in the `frontend` package with FlowFi-specific content. Also added package-specific `README.md` files for the `backend` and `contracts` directories to orient new contributors.
3. **CONTRIBUTING Guide Fixes**: Fixed the malformed YAML front-matter wrapper in `CONTRIBUTING.md` so the main heading renders correctly, updated all `flowfi/flowfi` URLs to the correct `LabsCrypt/flowfi` repository, and corrected the PostgreSQL port documentation to `5433` (matching the `docker-compose.yml` mapping).
4. **Authentication Documentation Link**: Added a direct link to `backend/docs/AUTHENTICATION.md` in the root `README.md`'s API Documentation section, and optionally cross-linked it from the Authentication Flow section in `docs/ARCHITECTURE.md` to ensure contributors have an entry point to the auth model.

## Files Touched
- `README.md`
- `frontend/README.md`
- `backend/README.md`
- `contracts/README.md`
- `CONTRIBUTING.md`
- `docs/ARCHITECTURE.md`

## Testing Instructions
- Verify that `README.md` and `CONTRIBUTING.md` render properly on GitHub without stray markdown characters.
- Ensure the links point to the correct `LabsCrypt/flowfi` repository and that the cross-links (e.g., to the Authentication Doc) resolve successfully.
```