### PR TITLE
test: add unit tests for useSettings hook and formatAmountWithPreference utility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,3 +65,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # ── Docker ─────────────────────────────────────────────────────────────────
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:15
+        image: postgres:16-alpine@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,40 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  backend-docker:
+    name: Backend Docker Image CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check changed files
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'docker-compose.yml'
+
+      - name: Build Docker Image
+        if: steps.filter.outputs.backend == 'true' || github.event_name == 'push'
+        run: docker build -f backend/Dockerfile backend -t flowfi-backend:test
+
+      - name: Docker Compose Build
+        if: steps.filter.outputs.backend == 'true' || github.event_name == 'push'
+        run: docker compose build
+
+      - name: Boot and Check Health
+        if: steps.filter.outputs.backend == 'true' || github.event_name == 'push'
+        run: |
+          docker compose up -d postgres
+          sleep 10
+          docker compose run --rm -e DATABASE_URL=postgresql://flowfi:flowfi_dev_password@postgres:5432/flowfi backend npx -y prisma db push --accept-data-loss
+          docker compose up -d backend
+          sleep 15
+          curl --fail http://localhost:3001/health || (docker compose logs backend && exit 1)
+
   contracts:
     name: Soroban Contracts CI
     runs-on: ubuntu-latest

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS builder
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
 
 WORKDIR /app
 
@@ -11,7 +11,7 @@ COPY prisma ./prisma
 
 RUN npm run build
 
-FROM node:20-alpine AS runner
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS runner
 
 WORKDIR /app
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,10 +3,11 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+RUN npm install
 
 COPY tsconfig.json ./
 COPY src ./src
+COPY prisma ./prisma
 
 RUN npm run build
 
@@ -17,7 +18,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 COPY package*.json ./
-RUN npm ci --only=production
+RUN npm install --omit=dev
 
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/src/generated ./src/generated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16-alpine@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb
     container_name: flowfi-postgres
     environment:
       POSTGRES_USER: flowfi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,11 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3001/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     restart: unless-stopped
 
 volumes:

--- a/frontend/src/hooks/useSettings.test.ts
+++ b/frontend/src/hooks/useSettings.test.ts
@@ -1,0 +1,167 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  useSettings,
+  STORAGE_KEYS,
+  formatAmountWithPreference,
+  DEFAULT_SETTINGS
+} from './useSettings';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value.toString();
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    })
+  };
+})();
+
+vi.stubGlobal('localStorage', localStorageMock);
+
+describe('useSettings and formatAmountWithPreference', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe('useSettings hook', () => {
+    it('initializes with default settings if localStorage is empty', async () => {
+      const { result } = renderHook(() => useSettings());
+      
+      await waitFor(() => {
+        expect(result.current.isHydrated).toBe(true);
+      });
+
+      expect(result.current.theme).toBe(DEFAULT_SETTINGS.theme);
+      expect(result.current.displayCurrency).toBe(DEFAULT_SETTINGS.displayCurrency);
+      expect(result.current.amountFormat).toBe(DEFAULT_SETTINGS.amountFormat);
+      expect(result.current.decimalPlaces).toBe(DEFAULT_SETTINGS.decimalPlaces);
+    });
+
+    it('hydrates settings from pre-seeded localStorage values', async () => {
+      localStorage.setItem(STORAGE_KEYS.theme, 'light');
+      localStorage.setItem(STORAGE_KEYS.displayCurrency, 'XLM');
+      localStorage.setItem(STORAGE_KEYS.amountFormat, 'compact');
+      localStorage.setItem(STORAGE_KEYS.decimalPlaces, '4');
+
+      const { result } = renderHook(() => useSettings());
+      
+      await waitFor(() => {
+        expect(result.current.isHydrated).toBe(true);
+      });
+
+      expect(result.current.theme).toBe('light');
+      expect(result.current.displayCurrency).toBe('XLM');
+      expect(result.current.amountFormat).toBe('compact');
+      expect(result.current.decimalPlaces).toBe(4);
+    });
+
+    it('updates state and localStorage when setTheme is called', async () => {
+      const { result } = renderHook(() => useSettings());
+      
+      await waitFor(() => expect(result.current.isHydrated).toBe(true));
+
+      act(() => {
+        result.current.setTheme('light');
+      });
+
+      expect(result.current.theme).toBe('light');
+      expect(localStorage.getItem(STORAGE_KEYS.theme)).toBe('light');
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+
+    it('updates state and localStorage when setDecimalPlaces is called', async () => {
+      const { result } = renderHook(() => useSettings());
+      
+      await waitFor(() => expect(result.current.isHydrated).toBe(true));
+
+      act(() => {
+        result.current.setDecimalPlaces(2);
+      });
+
+      expect(result.current.decimalPlaces).toBe(2);
+      expect(localStorage.getItem(STORAGE_KEYS.decimalPlaces)).toBe('2');
+    });
+
+    it('updates state and localStorage when setDisplayCurrency is called', async () => {
+      const { result } = renderHook(() => useSettings());
+      
+      await waitFor(() => expect(result.current.isHydrated).toBe(true));
+
+      act(() => {
+        result.current.setDisplayCurrency('USDC');
+      });
+
+      expect(result.current.displayCurrency).toBe('USDC');
+      expect(localStorage.getItem(STORAGE_KEYS.displayCurrency)).toBe('USDC');
+    });
+
+    it('updates state and localStorage when setAmountFormat is called', async () => {
+      const { result } = renderHook(() => useSettings());
+      
+      await waitFor(() => expect(result.current.isHydrated).toBe(true));
+
+      act(() => {
+        result.current.setAmountFormat('compact');
+      });
+
+      expect(result.current.amountFormat).toBe('compact');
+      expect(localStorage.getItem(STORAGE_KEYS.amountFormat)).toBe('compact');
+    });
+  });
+
+  describe('formatAmountWithPreference', () => {
+    it('truncates to 2 decimals and trims trailing zeros', () => {
+      localStorage.setItem(STORAGE_KEYS.decimalPlaces, '2');
+      
+      expect(formatAmountWithPreference(15000000n)).toBe('1.5');
+      expect(formatAmountWithPreference(10000000n)).toBe('1');
+      expect(formatAmountWithPreference(15678900n)).toBe('1.56');
+    });
+
+    it('truncates to 4 decimals and trims trailing zeros', () => {
+      localStorage.setItem(STORAGE_KEYS.decimalPlaces, '4');
+      
+      expect(formatAmountWithPreference(15000000n)).toBe('1.5');
+      expect(formatAmountWithPreference(15670000n)).toBe('1.567');
+      expect(formatAmountWithPreference(15678900n)).toBe('1.5678');
+    });
+
+    it('truncates to 7 decimals and trims trailing zeros', () => {
+      localStorage.setItem(STORAGE_KEYS.decimalPlaces, '7');
+      
+      expect(formatAmountWithPreference(15000000n)).toBe('1.5');
+      expect(formatAmountWithPreference(15678900n)).toBe('1.56789');
+      expect(formatAmountWithPreference(15678901n)).toBe('1.5678901');
+    });
+
+    it('handles bigint inputs correctly', () => {
+      localStorage.setItem(STORAGE_KEYS.decimalPlaces, '4');
+      expect(formatAmountWithPreference(1000000000n)).toBe('100');
+      expect(formatAmountWithPreference(1001234567n)).toBe('100.1234');
+    });
+
+    it('handles number inputs correctly', () => {
+      localStorage.setItem(STORAGE_KEYS.decimalPlaces, '4');
+      expect(formatAmountWithPreference(100.1234)).toBe('100.1234');
+      expect(formatAmountWithPreference(100.1234567)).toBe('100.1234');
+    });
+
+    it('handles string inputs correctly', () => {
+      localStorage.setItem(STORAGE_KEYS.decimalPlaces, '4');
+      // string representing 100.1234 * 10^7 = 1001234000
+      expect(formatAmountWithPreference('1001234000')).toBe('100.1234');
+    });
+  });
+});

--- a/frontend/src/lib/api/streams.test.ts
+++ b/frontend/src/lib/api/streams.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach, vi, Mock } from 'vitest';
+import { fetchIncomingStreams } from './streams';
+import { TOKEN_ADDRESSES } from '@/lib/soroban';
+import type { BackendStream } from '@/lib/api-types';
+
+describe('fetchIncomingStreams', () => {
+  const recipientPublicKey = 'GBXHQ...';
+  let originalFetch: typeof global.fetch;
+  let fetchMock: Mock;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  const mockStream: BackendStream = {
+    id: 'db-id-1',
+    streamId: 1,
+    sender: 'GBXHQYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYZZZZ',
+    recipient: 'GBXHQ...',
+    tokenAddress: TOKEN_ADDRESSES.USDC,
+    ratePerSecond: '10000000', // 1 USDC per second
+    depositedAmount: '100000000', // 10 USDC
+    withdrawnAmount: '50000000', // 5 USDC
+    startTime: 1000,
+    lastUpdateTime: 2000,
+    isActive: true,
+    isPaused: false,
+    pausedAt: null,
+    totalPausedDuration: 0,
+  };
+
+  it('advances to the next endpoint on 404 and returns mapped results from the first 2xx', async () => {
+    // First call returns 404
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    });
+
+    // Second call returns 200 with an array
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [mockStream],
+    });
+
+    const result = await fetchIncomingStreams(recipientPublicKey);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('db-id-1');
+  });
+
+  it('handles array response shapes correctly', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [mockStream, { ...mockStream, id: 'db-id-2' }],
+    });
+
+    const result = await fetchIncomingStreams(recipientPublicKey);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('db-id-1');
+    expect(result[1].id).toBe('db-id-2');
+  });
+
+  it('handles { data: [] } response shapes correctly', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [mockStream] }),
+    });
+
+    const result = await fetchIncomingStreams(recipientPublicKey);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('db-id-1');
+  });
+
+  it('maps mapBackendStream output correctly: token label resolution + fallback', async () => {
+    const unknownTokenStream = {
+      ...mockStream,
+      tokenAddress: 'CBXHQZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZYYYY',
+    };
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [mockStream, unknownTokenStream],
+    });
+
+    const result = await fetchIncomingStreams(recipientPublicKey);
+
+    // Resolution based on TOKEN_ADDRESSES
+    expect(result[0].token).toBe('USDC');
+    expect(result[0].tokenAddress).toBe(TOKEN_ADDRESSES.USDC);
+
+    // Fallback format
+    expect(result[1].token).toBe('CBXHQZ...YYYY');
+    expect(result[1].tokenAddress).toBe(unknownTokenStream.tokenAddress);
+  });
+
+  it('maps mapBackendStream output correctly: toTokenAmount scaling', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [mockStream],
+    });
+
+    const result = await fetchIncomingStreams(recipientPublicKey);
+    
+    // 10000000 stroops = 1 token
+    expect(result[0].ratePerSecond).toBe(1);
+    // 100000000 stroops = 10 tokens
+    expect(result[0].deposited).toBe(10);
+    // 50000000 stroops = 5 tokens
+    expect(result[0].withdrawn).toBe(5);
+  });
+
+  it('maps mapBackendStream output correctly: status', async () => {
+    const activeStream = { ...mockStream, isActive: true, isPaused: false };
+    const pausedStream = { ...mockStream, isActive: true, isPaused: true };
+    const completedStream = { ...mockStream, isActive: false, isPaused: false };
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [activeStream, pausedStream, completedStream],
+    });
+
+    const result = await fetchIncomingStreams(recipientPublicKey);
+
+    expect(result[0].status).toBe('Active');
+    expect(result[1].status).toBe('Paused');
+    expect(result[2].status).toBe('Completed');
+  });
+
+  it('throws the last error when all candidates fail (non-404)', async () => {
+    // Both endpoints return 500
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+
+    await expect(fetchIncomingStreams(recipientPublicKey)).rejects.toThrow(
+      /Failed to fetch incoming streams \(500\)/
+    );
+  });
+
+  it('throws the last error when all candidates fail (404)', async () => {
+    // Both endpoints return 404
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    });
+
+    await expect(fetchIncomingStreams(recipientPublicKey)).rejects.toThrow(
+      /Endpoint not found:/
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -526,7 +526,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -534,7 +534,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -562,7 +562,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -614,7 +614,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -3600,7 +3600,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -8309,7 +8309,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8371,7 +8370,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8393,7 +8391,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8415,7 +8412,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8437,7 +8433,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8479,7 +8474,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8501,7 +8495,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8521,7 +8514,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8782,7 +8774,7 @@
     },
     "node_modules/magicast": {
       "version": "0.3.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.4",


### PR DESCRIPTION
Closes #882 

Here is a summary of the changes made:

Created frontend/src/hooks/useSettings.test.ts:
Simulated the global localStorage environment properly for vitest to support the tests.
Settings State and Storage Test: Validated that setTheme, setDisplayCurrency, setAmountFormat, and setDecimalPlaces all correctly update both the hook's returned state as well as their respective STORAGE_KEYS in localStorage.
Hydration Test: Validated that if localStorage has existing seeded values, the useSettings hook correctly hydrates state from them on mount.
Formatting Tests: Added specific test scenarios for formatAmountWithPreference():
Tested that the function correctly truncates based on predefined decimals (2, 4, 7).
Ensured trailing zeros after decimal truncation are effectively trimmed.
Confirmed it appropriately resolves and calculates against various input primitive types (bigint, number, and string).

Closes #884 
Here's a breakdown of the implementation:

Created frontend/src/lib/api/streams.test.ts:
Mocked the global fetch via vi.fn() to observe API calls without triggering live network requests.
Endpoint Fallback: Added tests to ensure that the function accurately loops to the next getStreamsEndpointCandidates endpoint if a 404 status occurs, and verified it appropriately handles throwing the last captured error if all candidates fail.
Payload Shapes: Included coverage guaranteeing that responses in both the direct array format [ ... ] and object property format { data: [ ... ] } are successfully parsed and flattened.
Mapping (mapBackendStream): Created specialized tests confirming logic handling in:
Token Label Resolution: Correctly assigns known token labels based on the mapping (e.g. USDC to its address) and checks that it defaults to address substring truncating correctly (XXX...YYY) as a fallback for unknown addresses.
Stroop Scaling: Verified that values output by toTokenAmount() are being processed accurately for ratePerSecond, deposited, and withdrawn token amounts.
Stream Status: Ensured toIncomingStreamStatus successfully routes conditions for Active, Paused, and Completed.


Closes #889 
Here is a summary of the implemented changes:

Added backend-docker job in .github/workflows/ci.yml:
The job uses dorny/paths-filter to selectively run whenever there are changes targeting backend/** or docker-compose.yml via PRs, or on normal pushes to the repository.
It executes docker build -f backend/Dockerfile backend and docker compose build.
It performs the regression health check by starting Postgres, executing database schema pushes through npx -y prisma db push, booting the backend image, and verifying availability via curl --fail http://localhost:3001/health.
Fixed backend/Dockerfile Regressions:
Swapped npm ci with npm install in the container configuration since the package-lock.json lives at the workspace root and is inaccessible within the localized backend build context.
Inserted a COPY prisma ./prisma command. Before this, the missing schema.prisma in the container meant npm run build's prisma generate step was failing silently or ignoring critical generated schema clients for the production runner.
Enhanced docker-compose.yml:
Injected a localized healthcheck script using wget --spider to natively verify http://localhost:3001/health in Docker. This establishes robust dependencies for local startups and avoids downstream failures when waiting for the backend to become active.

Closes #895 
Here's what was addressed:

Pinned Mutable Base Images: Updated backend/Dockerfile to pin node:20-alpine explicitly to its precise digest (sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293), preventing silent upstream changes from invalidating the build integrity.
Added Docker to Dependabot: Extended .github/dependabot.yml with the docker package-ecosystem. Dependabot is now configured to automatically bump digest tags when upstream fixes are released across both the /backend directory (for the Dockerfile) and the root / (for docker-compose.yml).
Postgres Version Alignment & Pinning: Updated the CI Postgres service in .github/workflows/ci.yml from postgres:15 to align with the rest of the application's environment (postgres:16-alpine). Furthermore, I also explicitly pinned both the CI service and the docker-compose.yml service to the specific digest hash for postgres:16-alpine to maintain strict reproducibility everywhere.
