### PR TITLE
Guard error handler after headers are sent

### DIFF
--- a/backend/src/middleware/error.middleware.ts
+++ b/backend/src/middleware/error.middleware.ts
@@ -14,6 +14,10 @@ export const errorHandler = (
 ) => {
     logger.error('Unhandled error:', err);
 
+    if (res.headersSent) {
+        return next(err);
+    }
+
     // Handle Zod Validation Errors
     if (err instanceof ZodError) {
         return res.status(400).json({

--- a/backend/tests/error.middleware.test.ts
+++ b/backend/tests/error.middleware.test.ts
@@ -44,4 +44,15 @@ describe('Error Middleware', () => {
     errorHandler(error, req as Request, res as Response, next);
     expect(res.status).toHaveBeenCalledWith(500);
   });
+
+  it('should delegate to next when headers were already sent', () => {
+    const error = new Error('Stream failed after headers');
+    res.headersSent = true;
+
+    errorHandler(error, req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledWith(error);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a 
es.headersSent guard to the global backend error handler.
- Delegates to 
ext(err) when a streamed or partial response has already written headers.
- Prevents the error middleware from attempting a second 
es.status(...).json(...) write after headers are sent.
- Extends the existing error middleware test coverage for the streamed-response case.
- Asserts that 
ext(err) is called and neither 
es.status nor 
es.json is invoked when headersSent is true.

Closes #819
Closes #817 
Closes #818 
Closes #820

## Notes

This keeps the existing error response shapes unchanged. The only behavioral change is for post-header failures, where Express should continue through the normal error finalization path instead of the app trying to write another JSON response.

## Testing

- Not run: backend dependencies are not installed in this worktree.
- Ran: git diff --check.