### PR TITLE
fix: align OpenAPI events limit max with code constant (500 -> 200)

### DIFF
--- a/backend/src/routes/v1/stream.routes.ts
+++ b/backend/src/routes/v1/stream.routes.ts
@@ -91,8 +91,8 @@ router.get('/:streamId', getStream);
  *           type: integer
  *           default: 50
  *           minimum: 1
- *           maximum: 500
- *         description: "Number of events to return per page (default: 50, max: 500)"
+ *           maximum: 200
+ *         description: "Number of events to return per page (default: 50, max: 200)"
  *       - in: query
  *         name: offset
  *         schema:


### PR DESCRIPTION
PR #814 Fix OpenAPI events limit max mismatch (500 → 200)

## Problem

`GET /v1/streams/{streamId}/events` documented `limit` parameter with `maximum: 500` in `stream.routes.ts:94`, but the runtime code in `events.routes.ts:24` defines `MAX_EVENTS_PAGE_SIZE = 200` and the controller clamps to that value. A client requesting `limit=400` would silently receive at most 200 rows, contradicting the published contract.

## Change

- `backend/src/routes/v1/stream.routes.ts:94-95` — Changed `maximum: 500` → `maximum: 200` and `max: 500` → `max: 200` in the description to match `MAX_EVENTS_PAGE_SIZE`.

## Verification

The `/api-docs.json` endpoint is generated dynamically from the JSDoc annotations via `swagger-jsdoc`, so the corrected value will appear automatically.

Closes #814 