### PR TITLE
Settings page labels lack htmlFor

### DIFF
--- a/frontend/src/app/settings/settings-content.tsx
+++ b/frontend/src/app/settings/settings-content.tsx
@@ -242,8 +242,9 @@ export default function SettingsContent() {
 
             <div className="space-y-3 pl-12">
               <div>
-                <label className="text-sm text-white/60 dark:text-black/60">Default Token</label>
+                <label htmlFor="default-token" className="text-sm text-white/60 dark:text-black/60">Default Token</label>
                 <select
+                  id="default-token"
                   value={displayCurrency}
                   onChange={(e) => {
                     const val = e.target.value as DisplayCurrency;
@@ -259,8 +260,12 @@ export default function SettingsContent() {
               </div>
 
               <div>
-                <label className="text-sm text-white/60 dark:text-black/60">Amount Format</label>
-                <div className="flex gap-2 mt-1">
+                <label id="amount-format-label" className="text-sm text-white/60 dark:text-black/60">Amount Format</label>
+                <div
+                  className="flex gap-2 mt-1"
+                  role="radiogroup"
+                  aria-labelledby="amount-format-label"
+                >
                   {(["full", "compact"] as const).map((fmt) => (
                     <button
                       key={fmt}
@@ -281,8 +286,12 @@ export default function SettingsContent() {
               </div>
 
               <div>
-                <label className="text-sm text-white/60 dark:text-black/60">Decimal Places</label>
-                <div className="flex gap-2 mt-1">
+                <label id="decimal-places-label" className="text-sm text-white/60 dark:text-black/60">Decimal Places</label>
+                <div
+                  className="flex gap-2 mt-1"
+                  role="radiogroup"
+                  aria-labelledby="decimal-places-label"
+                >
                   {([2, 4, 7] as DecimalPlaces[]).map((places) => (
                     <button
                       key={places}


### PR DESCRIPTION
## Description
closes #630 
This PR resolves accessibility (a11y) issues on the Settings page where screen readers are unable to announce which controls the labels belong to. Specifically:
1. The **Default Token** select element was not associated with its label.
2. The **Amount Format** button group had no label association.
3. The **Decimal Places** button group had no label association.

These changes ensure screen readers correctly announce the labels and group context.

