### PR TITLE
create_stream rustdoc Errors omits InvalidRate

### DIFF
--- a/contracts/stream_contract/src/lib.rs
+++ b/contracts/stream_contract/src/lib.rs
@@ -176,6 +176,7 @@ impl StreamContract {
     /// # Errors
     /// - `InvalidAmount`   — `amount` ≤ 0.
     /// - `InvalidDuration` — `duration` is 0.
+    /// - `InvalidRate`     — `net_amount / duration` rounds to zero.
     /// - `InvalidTokenAddress` — `token_address` is not a token contract.
     pub fn create_stream(
         env: Env,


### PR DESCRIPTION
### docs: Add InvalidRate to create_stream # Errors list
closes #797 
This PR addresses a documentation inconsistency in the `create_stream` function. The function can return `StreamError::InvalidRate` when the calculated rate per second truncates to zero, but this error was missing from the function's doc comment in the `# Errors` section.

This change updates the documentation to include `InvalidRate`, ensuring that developers are aware of all possible error conditions when using the function.

#### Why this matters

The `# Errors` section for `create_stream` was out of sync with the implementation. It was missing the `InvalidRate` error, which can occur when `net_amount / duration` truncates to 0. Accurate documentation is crucial for contract usability and helps prevent integration errors.

#### Acceptance Criteria

- The `InvalidRate` error is added to the `# Errors` list in the `create_stream` function's doc comment in `contracts/stream_contract/src/lib.rs`.

#### Out of Scope

- Updating the `# Errors` sections for any other functions.
