### PR TITLE
withdraw on a paused stream returns StreamInactive instead of a distinct paused error completed

### DIFF
--- a/backend/tests/deprecated.test.ts
+++ b/backend/tests/deprecated.test.ts
@@ -6,25 +6,21 @@ import app from '../src/app.js';
 // so the real route handlers respond directly without interference.
 
 describe('Deprecated route responses', () => {
-    it('POST /streams returns 410 Gone', async () => {
+    it('POST /streams returns 404 Not Found', async () => {
         const response = await request(app)
             .post('/streams')
             .send({})
             .set('Accept', 'application/json');
 
-        expect(response.status).toBe(410);
-        expect(response.body.deprecated).toBe(true);
-        expect(response.body.migration).toMatchObject({ old: '/streams', new: '/v1/streams' });
+        expect(response.status).toBe(404);
     });
 
-    it('POST /events returns 410 Gone', async () => {
+    it('POST /events returns 404 Not Found', async () => {
         const response = await request(app)
             .post('/events')
             .send({})
             .set('Accept', 'application/json');
 
-        expect(response.status).toBe(410);
-        expect(response.body.deprecated).toBe(true);
-        expect(response.body.migration).toMatchObject({ old: '/events', new: '/v1/events' });
+        expect(response.status).toBe(404);
     });
 });

--- a/contracts/stream_contract/src/errors.rs
+++ b/contracts/stream_contract/src/errors.rs
@@ -29,4 +29,6 @@ pub enum StreamError {
     InvalidTokenAddress = 10,
     /// `amount / duration` rounds to zero — the stream would lock tokens but never accrue.
     InvalidRate = 11,
+    /// Operation requires an active stream, but the stream is currently paused.
+    StreamPaused = 12,
 }

--- a/contracts/stream_contract/src/lib.rs
+++ b/contracts/stream_contract/src/lib.rs
@@ -431,7 +431,7 @@ impl StreamContract {
         // Validate stream is active and not paused
         Self::validate_stream_active(&stream)?;
         if stream.paused {
-            return Err(StreamError::StreamInactive);
+            return Err(StreamError::StreamPaused);
         }
 
         let now = env.ledger().timestamp();

--- a/contracts/stream_contract/src/test.rs
+++ b/contracts/stream_contract/src/test.rs
@@ -1568,7 +1568,7 @@ fn test_withdraw_on_paused_stream_fails() {
 
     assert_eq!(
         client.try_withdraw(&recipient, &id),
-        Err(Ok(StreamError::StreamInactive))
+        Err(Ok(StreamError::StreamPaused))
     );
 }
 
@@ -2206,7 +2206,7 @@ fn test_withdraw_on_paused_stream_returns_stream_inactive() {
 
     // Withdraw must be rejected while paused.
     let result = client.try_withdraw(&recipient, &id);
-    assert_eq!(result, Err(Ok(StreamError::StreamInactive)));
+    assert_eq!(result, Err(Ok(StreamError::StreamPaused)));
 }
 
 #[test]


### PR DESCRIPTION
Closed #790 