### PR TITLE
fix(contracts): preserve accrued vest time on stream top-up (closes #786)

### DIFF
--- a/contracts/stream_contract/src/lib.rs
+++ b/contracts/stream_contract/src/lib.rs
@@ -288,9 +288,10 @@ impl StreamContract {
         // Collect protocol fee and get net amount
         let net_amount = Self::collect_fee(&env, &stream.token_address, amount, stream_id);
 
-        // Update stream state
+        // Update stream state. `last_update_time` is intentionally left untouched:
+        // it is the accrual anchor for `calculate_claimable`, and advancing it to
+        // `now` would discard any already-vested, unwithdrawn tokens.
         stream.deposited_amount += net_amount;
-        stream.last_update_time = env.ledger().timestamp();
 
         save_stream(&env, stream_id, &stream);
 

--- a/contracts/stream_contract/src/test.rs
+++ b/contracts/stream_contract/src/test.rs
@@ -497,6 +497,53 @@ fn test_top_up_emits_event() {
     assert_eq!(payload.new_deposited_amount, 15_000);
 }
 
+#[test]
+fn test_top_up_preserves_already_accrued_claimable() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    mint(&env, &token, &sender, 2_000);
+
+    let client = create_contract(&env);
+    let id = client.create_stream(&sender, &recipient, &token, &1_000, &1_000);
+
+    // Recipient vests 900 tokens (rate 1/sec) before the top-up.
+    env.ledger().with_mut(|l| l.timestamp += 900);
+    assert_eq!(client.get_claimable_amount(&id), Some(900));
+
+    client.top_up_stream(&sender, &id, &100);
+
+    // Already-accrued, unwithdrawn time must survive the top-up.
+    assert_eq!(client.get_claimable_amount(&id), Some(900));
+}
+
+#[test]
+fn test_top_up_then_cancel_pays_pre_topup_accrued() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    mint(&env, &token, &sender, 2_000);
+
+    let client = create_contract(&env);
+    let id = client.create_stream(&sender, &recipient, &token, &1_000, &1_000);
+
+    env.ledger().with_mut(|l| l.timestamp += 900);
+    client.top_up_stream(&sender, &id, &100);
+
+    let token_client = token::Client::new(&env, &token);
+    let recipient_balance_before = token_client.balance(&recipient);
+
+    // Cancel immediately after the top-up — no further time should accrue.
+    client.cancel_stream(&sender, &id);
+
+    let recipient_balance_after = token_client.balance(&recipient);
+    assert_eq!(recipient_balance_after - recipient_balance_before, 900);
+}
+
 // ─── withdraw ────────────────────────────────────────────────────────────────
 
 #[test]
@@ -1756,6 +1803,34 @@ fn test_top_up_while_paused_increases_deposited() {
     let new_deposited = client.get_stream(&id).unwrap().deposited_amount;
 
     assert!(new_deposited > old_deposited);
+}
+
+#[test]
+fn test_top_up_while_paused_does_not_advance_last_update_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    mint(&env, &token, &sender, 2_000);
+
+    let client = create_contract(&env);
+    let id = client.create_stream(&sender, &recipient, &token, &1_000, &1_000);
+
+    // Accrue 300s, then pause.
+    env.ledger().with_mut(|l| l.timestamp += 300);
+    client.pause_stream(&sender, &id);
+
+    // More ledger time passes while paused; top up during this window.
+    env.ledger().with_mut(|l| l.timestamp += 200);
+    client.top_up_stream(&sender, &id, &100);
+
+    let stream = client.get_stream(&id).unwrap();
+    assert!(stream.last_update_time <= stream.paused_at.unwrap());
+
+    // Claimable should still reflect the 300s accrued before the pause, not be
+    // wiped out by the top-up pushing last_update_time past paused_at.
+    assert_eq!(client.get_claimable_amount(&id), Some(300));
 }
 
 #[test]


### PR DESCRIPTION
(closes #786)

## Summary

`top_up_stream` was unconditionally resetting `stream.last_update_time` to the
current ledger timestamp on every call. Since `calculate_claimable` uses
`last_update_time` as the accrual anchor (`elapsed = effective_now -
last_update_time`), this silently discarded any vested-but-unwithdrawn
balance the moment a top-up happened.

Concrete impact: for a 1000-token / 1000s stream (rate 1/s), if the recipient
had 900 unwithdrawn tokens vested at `t=900` and the sender called
`top_up_stream(+100)`, `last_update_time` jumped to `900`, zeroing
`get_claimable_amount`. A subsequent `cancel_stream` at `t=901` would then pay
the recipient only `1` token and refund `1099` to the sender — letting the
sender reclaim ~899 tokens the recipient had already earned.

## Fix

- Removed the `stream.last_update_time = env.ledger().timestamp()` assignment
  in `top_up_stream` (`contracts/stream_contract/src/lib.rs`) so prior accrued
  time is preserved across top-ups, including while a stream is paused
  (`last_update_time` is never pushed past `paused_at`).

## Tests added

- `test_top_up_preserves_already_accrued_claimable` — after
  `create_stream(1000, 1000s)`, advancing 900s and topping up by 100 keeps
  `get_claimable_amount` at 900 instead of dropping to 0.
- `test_top_up_then_cancel_pays_pre_topup_accrued` — topping up and
  immediately cancelling pays the recipient exactly the pre-top-up accrued
  amount.
- `test_top_up_while_paused_does_not_advance_last_update_time` — topping up a
  paused stream does not push `last_update_time` past `paused_at`, and
  claimable amount still reflects only the time accrued before the pause.

## Scope

- Out of scope per the issue: protocol fee logic and frontend/backend top-up
  wiring were left untouched.
- Files touched: `contracts/stream_contract/src/lib.rs`,
  `contracts/stream_contract/src/test.rs`.
