### PR TITLE
chore(#620): drop unused stellar-sdk dependency

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -32,7 +32,6 @@
     "express-rate-limit": "^8.5.2",
     "ioredis": "^5.11.1",
     "pg": "^8.21.0",
-    "stellar-sdk": "^13.3.0",
     "swagger-jsdoc": "^6.3.0",
     "swagger-ui-express": "^5.0.1",
     "winston": "^3.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "express-rate-limit": "^8.5.2",
         "ioredis": "^5.11.1",
         "pg": "^8.21.0",
-        "stellar-sdk": "^13.3.0",
         "swagger-jsdoc": "^6.3.0",
         "swagger-ui-express": "^5.0.1",
         "winston": "^3.11.0",
@@ -2937,10 +2936,6 @@
         "semver": "7.7.1"
       }
     },
-    "node_modules/@stellar/js-xdr": {
-      "version": "3.1.2",
-      "license": "Apache-2.0"
-    },
     "node_modules/@stellar/stellar-base": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-15.0.0.tgz",
@@ -4457,44 +4452,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bare-addon-resolve": {
-      "version": "1.10.0",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-module-resolve": "^1.10.0",
-        "bare-semver": "^1.0.0"
-      },
-      "peerDependencies": {
-        "bare-url": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-url": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-module-resolve": {
-      "version": "1.12.1",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-semver": "^1.0.0"
-      },
-      "peerDependencies": {
-        "bare-url": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-url": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-semver": {
-      "version": "1.0.2",
-      "license": "Apache-2.0",
-      "optional": true
     },
     "node_modules/base32.js": {
       "version": "0.1.0",
@@ -10137,17 +10094,6 @@
         "url": "https://github.com/sponsors/remeda"
       }
     },
-    "node_modules/require-addon": {
-      "version": "1.2.0",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-addon-resolve": "^1.3.0"
-      },
-      "engines": {
-        "bare": ">=1.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "license": "MIT",
@@ -10783,14 +10729,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/sodium-native": {
-      "version": "4.3.3",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "require-addon": "^1.1.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
@@ -10845,41 +10783,6 @@
       "version": "3.10.0",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/stellar-sdk": {
-      "version": "13.3.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/stellar-base": "^13.1.0",
-        "axios": "^1.8.4",
-        "bignumber.js": "^9.3.0",
-        "eventsource": "^2.0.2",
-        "feaxios": "^0.0.23",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/stellar-sdk/node_modules/@stellar/stellar-base": {
-      "version": "13.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/js-xdr": "^3.1.2",
-        "base32.js": "^0.1.0",
-        "bignumber.js": "^9.1.2",
-        "buffer": "^6.0.3",
-        "sha.js": "^2.3.6",
-        "tweetnacl": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "sodium-native": "^4.3.3"
-      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -11660,10 +11563,6 @@
       "optionalDependencies": {
         "fsevents": "~2.3.3"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",


### PR DESCRIPTION
Closes #620 
## Summary

- Removes `stellar-sdk` from `backend/package.json` — no file under `backend/src` imports from `stellar-sdk`; all imports use `@stellar/stellar-sdk`
- Regenerates `package-lock.json` to reflect the removal

## Test plan

- [ ] `npm run build` passes in `backend/`
- [ ] `npm test` passes in `backend/`
- [ ] Confirm `grep -rn "from 'stellar-sdk'" backend/src` returns nothing