### PR TITLE
fix(ci): unbreak main - update sunset route test + ship prisma schema in runtime image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,6 +23,13 @@ RUN npm install --omit=dev
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/src/generated ./src/generated
 
+# Prisma 7 resolves the schema location and datasource url from prisma.config.ts,
+# and the schema itself lives under prisma/. The CI health-check runs
+# `prisma db push` inside this image, so both must be present in the runtime stage
+# (dotenv is a runtime dependency, so prisma.config.ts loads fine).
+COPY prisma ./prisma
+COPY prisma.config.ts ./
+
 EXPOSE 3001
 
 CMD ["npm", "start"]

--- a/backend/tests/deprecated.test.ts
+++ b/backend/tests/deprecated.test.ts
@@ -2,29 +2,28 @@ import { describe, it, expect } from 'vitest';
 import request from 'supertest';
 import app from '../src/app.js';
 
-// This file tests deprecated endpoints WITHOUT any Prisma mocking
-// so the real route handlers respond directly without interference.
+// The legacy unversioned /streams and /events routes were removed past their
+// sunset date (see fix(#619): "remove legacy /streams and /events handlers past
+// their sunset date"). They are no longer served, so they respond with 404.
+// This test locks in that they stay removed. If the intent is instead to keep a
+// permanent 410 Gone tombstone, restore the handlers rather than changing this.
 
-describe('Deprecated route responses', () => {
-    it('POST /streams returns 410 Gone', async () => {
+describe('Removed legacy routes', () => {
+    it('POST /streams is no longer served (404)', async () => {
         const response = await request(app)
             .post('/streams')
             .send({})
             .set('Accept', 'application/json');
 
-        expect(response.status).toBe(410);
-        expect(response.body.deprecated).toBe(true);
-        expect(response.body.migration).toMatchObject({ old: '/streams', new: '/v1/streams' });
+        expect(response.status).toBe(404);
     });
 
-    it('POST /events returns 410 Gone', async () => {
+    it('POST /events is no longer served (404)', async () => {
         const response = await request(app)
             .post('/events')
             .send({})
             .set('Accept', 'application/json');
 
-        expect(response.status).toBe(410);
-        expect(response.body.deprecated).toBe(true);
-        expect(response.body.migration).toMatchObject({ old: '/events', new: '/v1/events' });
+        expect(response.status).toBe(404);
     });
 });


### PR DESCRIPTION
## What

Fixes the two failures that have `main` CI red (**Backend CI** + **Backend Docker Image CI**), which is currently blocking every open PR.

### 1. Backend CI — stale deprecated-route test
`fix(#619)` (a6be7bc) deliberately removed the legacy unversioned `/streams` and `/events` `410` handlers past their sunset date, but `backend/tests/deprecated.test.ts` still asserted `410 Gone` with a migration body. Those paths now fall through to `404`, so the test failed (`expected 404 to be 410`). Updated the test to assert the routes are fully removed (`404`).

> If the intent is a permanent `410 Gone` tombstone instead, the fix would be to restore the handlers rather than change this test — flagging so you can decide. This aligns with the most recent commit (the deliberate removal).

### 2. Backend Docker Image CI — Prisma schema missing from the runtime image
The *Boot and Check Health* step runs `docker compose run backend npx -y prisma db push` **inside** the backend container, which fails with `Could not find Prisma Schema`. The runtime stage of `backend/Dockerfile` only copied `dist` + `src/generated`, not `prisma/` or `prisma.config.ts`. Under Prisma 7 the schema location **and** datasource url come from `prisma.config.ts` (the schema's `datasource db {}` block has no `url`), so both are required in the image. Copied them into the runner stage — `dotenv` is already a runtime dependency, so the config loads.

## Verification
- The test fix is guaranteed: the routes already return `404` (that's exactly what the failing run reported as "Received").
- The Docker fix makes the in-container `prisma db push` find the schema/config.

CI on this PR should show both jobs green; merging unbreaks `main`.
