### PR TITLE
ci: restore Backend Docker Image CI (fix the image instead of deleting the job)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,40 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  backend-docker:
+    name: Backend Docker Image CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check changed files
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'docker-compose.yml'
+
+      - name: Build Docker Image
+        if: steps.filter.outputs.backend == 'true' || github.event_name == 'push'
+        run: docker build -f backend/Dockerfile backend -t flowfi-backend:test
+
+      - name: Docker Compose Build
+        if: steps.filter.outputs.backend == 'true' || github.event_name == 'push'
+        run: docker compose build
+
+      - name: Boot and Check Health
+        if: steps.filter.outputs.backend == 'true' || github.event_name == 'push'
+        run: |
+          docker compose up -d postgres
+          sleep 10
+          docker compose run --rm -e DATABASE_URL=postgresql://flowfi:flowfi_dev_password@postgres:5432/flowfi backend npx -y prisma db push --accept-data-loss
+          docker compose up -d backend
+          sleep 15
+          curl --fail http://localhost:3001/health || (docker compose logs backend && exit 1)
+
   contracts:
     name: Soroban Contracts CI
     runs-on: ubuntu-latest

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,6 +23,11 @@ RUN npm install --omit=dev
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/src/generated ./dist/generated
 COPY --from=builder /app/prisma ./prisma
+# Prisma 7 reads the schema location and datasource url from prisma.config.ts,
+# and the schema's `datasource db {}` block has no inline url. The CI health
+# check runs `prisma db push` inside this image, so the config must be present
+# too (dotenv is a runtime dependency, so the config loads).
+COPY prisma.config.ts ./
 
 EXPOSE 3001
 


### PR DESCRIPTION
## What
Restores the **Backend Docker Image CI** job that #969 removed, and fixes the underlying image bug so the job actually passes, keeping deployment-image validation (image build + boot + `prisma db push` + healthcheck) rather than dropping that coverage.

## Root cause
The job's *Boot and Check Health* step runs `docker compose run backend npx -y prisma db push` **inside** the backend container, which failed with `Could not find Prisma Schema`. #969 fixed the build and copied `prisma/`, but the schema's `datasource db {}` block has **no inline url** — under Prisma 7 the schema path and datasource url are read from `prisma.config.ts`, which was still missing from the runtime image.

## Fix
- `backend/Dockerfile`: also `COPY prisma.config.ts ./` into the runner stage. `dotenv` is a runtime dependency so the config loads, and the datasource url resolves from `DATABASE_URL` (passed to the health check via `-e`).
- `.github/workflows/ci.yml`: restore the `backend-docker` job verbatim.

## Verification
This PR's CI runs the restored job end-to-end (build image → boot → `prisma db push` → healthcheck). It should pass; if it doesn't, the job stays failing-visible rather than silently absent.
