### PR TITLE
Add test for rounded-zero protocol fee

### DIFF
--- a/contracts/stream_contract/src/lib.rs
+++ b/contracts/stream_contract/src/lib.rs
@@ -658,6 +658,7 @@ impl StreamContract {
     /// emits a `fee_collected` event, and returns the net amount.
     ///
     /// If no protocol config exists or the fee rate is 0, returns `amount` unchanged.
+    /// If fee calculation truncates to 0, no transfer/event occurs and `amount` is unchanged.
     /// Time complexity: O(1).
     fn collect_fee(env: &Env, token_address: &Address, amount: i128, stream_id: u64) -> i128 {
         match try_load_config(env) {

--- a/contracts/stream_contract/src/test.rs
+++ b/contracts/stream_contract/src/test.rs
@@ -825,6 +825,40 @@ fn test_no_fee_event_when_fee_rate_is_zero() {
 }
 
 #[test]
+fn test_no_fee_transfer_or_event_when_fee_rounds_to_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    mint(&env, &token, &sender, 1_000);
+
+    let client = create_contract(&env);
+    let token_client = token::Client::new(&env, &token);
+
+    // Non-zero fee rate, but tiny amount => fee rounds down to 0:
+    // 1 * 200 / 10_000 = 0
+    client.initialize(&admin, &treasury, &200);
+    let id = client.create_stream(&sender, &Address::generate(&env), &token, &1, &1);
+
+    assert_eq!(token_client.balance(&treasury), 0);
+
+    let s = client.get_stream(&id).unwrap();
+    assert_eq!(s.deposited_amount, 1);
+
+    let events = env.events().all();
+    let fee_event = events.iter().find(|e| {
+        Symbol::try_from_val(&env, &e.1.get(0).unwrap()).unwrap()
+            == Symbol::new(&env, "fee_collected")
+    });
+    assert!(
+        fee_event.is_none(),
+        "fee_collected must not fire when rounded fee is 0"
+    );
+}
+
+#[test]
 fn test_no_fee_without_protocol_config() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Closes #794 

**Description**
This PR adds a focused contract test covering the case where a non-zero protocol fee rate produces a rounded fee of zero for very small amounts.

**What changed**
- Added a single sentence of documentation in lib.rs
  - clarifies that when fee calculation truncates to zero, no transfer or `fee_collected` event occurs and the original amount is returned unchanged
- Added a new test in test.rs
  - `test_no_fee_transfer_or_event_when_fee_rounds_to_zero`
  - verifies a tiny stream amount with a non-zero fee rate does not transfer funds to treasury
  - ensures no `fee_collected` event is emitted

**Why**
- strengthens protocol fee behavior guarantees
- covers the edge case where fee rounding would otherwise imply an incorrect treasury transfer or event emission
- prevents regressions for minimal stream amounts under the current fee calculation

**Testing**
- contract test added in test.rs

**Notes**
- This PR is intentionally scoped to the rounded-zero fee edge case only.
- No frontend or unrelated backend files are included.