### PR TITLE
Add test for update_fee_config NotInitialized path

### DIFF
--- a/contracts/stream_contract/src/test.rs
+++ b/contracts/stream_contract/src/test.rs
@@ -181,6 +181,20 @@ fn test_update_fee_config_rejects_invalid_fee_rate() {
 }
 
 #[test]
+fn test_update_fee_config_rejects_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = create_contract(&env);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    // Call update_fee_config before initialize
+    let result = client.try_update_fee_config(&admin, &treasury, &100);
+    assert_eq!(result, Err(Ok(StreamError::NotInitialized)));
+}
+
+#[test]
 fn test_initialize_emits_event() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Description
Summary: Adds a test to cover the previously untested NotInitialized error path in the update_fee_config function.

Changes:

Added test_update_fee_config_rejects_not_initialized test in test.rs
The test calls try_update_fee_config before initialize and asserts that it returns Err(Ok(StreamError::NotInitialized))
Context: The update_fee_config function calls load_config(&env) at line 90 in lib.rs, which returns StreamError::NotInitialized when called before initialize. While this error path was already tested once via transfer_admin, there was no specific test calling update_fee_config on an uninitialized contract.

Testing:

Test passes: test_update_fee_config_rejects_not_initialized ... ok
closes #792 