### PR TITLE
[Infra] Document cargo ecosystem entry for contracts crate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
           - "patch"
 
   # ── Cargo: contracts ───────────────────────────────────────────────────────
+  # Rust/soroban-sdk crate updates (including security patches) for the
+  # Soroban contracts under /contracts. Schedule mirrors the npm entry above.
   - package-ecosystem: "cargo"
     directory: "/contracts"
     schedule:


### PR DESCRIPTION
## Summary

Issue #1060 requested a `cargo` package-ecosystem entry in `.github/dependabot.yml` for the Rust crate under `contracts/`, so soroban-sdk and other crate updates (including security patches) surface via Dependabot.

Investigation found the cargo entry already exists on `main` (added in e558f56, `directory: "/contracts"`, weekly/Monday schedule matching the npm entry). This PR adds a short comment documenting that entry's purpose and schedule alignment, closing out the remaining ask in the issue.

## Acceptance criteria

- [x] cargo package-ecosystem entry for `/contracts` present in `.github/dependabot.yml`
- [x] Update schedule matches existing npm entry (weekly, Monday)

## Test plan

- [x] Confirmed `contracts/` exists with `Cargo.toml` / `Cargo.lock`
- [x] Confirmed cargo entry schedule matches npm entry

Closes #1060