### PR TITLE
Add test coverage: SSE subscribe validation, health contract, Navbar mobile menu

### DIFF
--- a/backend/tests/integration/sse-subscribe.test.ts
+++ b/backend/tests/integration/sse-subscribe.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Integration tests for GET /v1/events/subscribe.
+ *
+ * Verifies malformed query params (e.g. a non-numeric streamId) are rejected
+ * with a clean 400 by the Zod schema, never surfacing as an uncaught 500.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    stream: {
+      findMany: vi.fn(),
+    },
+  },
+  sseService: {
+    broadcastToStream: vi.fn(),
+    broadcastToUser: vi.fn(),
+    addClient: vi.fn(),
+    removeClient: vi.fn(),
+    getClientCount: vi.fn().mockReturnValue(0),
+    getActiveIpCount: vi.fn().mockReturnValue(0),
+    getPerIpPeakConnections: vi.fn().mockReturnValue(0),
+    getMaxConnections: vi.fn().mockReturnValue(10000),
+    checkCapacity: vi.fn().mockReturnValue({ allowed: true }),
+    isShuttingDown: vi.fn().mockReturnValue(false),
+    initRedisSubscription: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../src/lib/prisma.js', () => ({
+  default: mocks.prisma,
+  prisma: mocks.prisma,
+}));
+
+vi.mock('../../src/services/sse.service.js', () => ({
+  sseService: mocks.sseService,
+  SSEService: vi.fn(() => mocks.sseService),
+}));
+
+vi.mock('../../src/lib/redis.js', () => ({
+  cache: {
+    get: vi.fn().mockReturnValue(null),
+    set: vi.fn(),
+    del: vi.fn(),
+    getMetadata: vi.fn(),
+    getStats: vi.fn().mockReturnValue({ hits: 0, misses: 0, hitRate: 0, itemCount: 0 }),
+    cleanup: vi.fn(),
+  },
+  isRedisAvailable: vi.fn().mockReturnValue(false),
+  getPublisher: vi.fn().mockReturnValue(null),
+  getSubscriber: vi.fn().mockReturnValue(null),
+  connectRedis: vi.fn().mockResolvedValue(undefined),
+  disconnectRedis: vi.fn().mockResolvedValue(undefined),
+}));
+
+import app from '../../src/app.js';
+import { signJwt } from '../../src/middleware/auth.js';
+
+const ADDR = 'GABC123XYZ456DEF789GHI012JKL345MNO678PQR901STU234VWX567YZA';
+const token = signJwt({ sub: ADDR, iat: Math.floor(Date.now() / 1000), exp: Math.floor(Date.now() / 1000) + 3600 });
+
+describe('GET /v1/events/subscribe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.prisma.stream.findMany.mockResolvedValue([]);
+  });
+
+  it('returns 400 with a descriptive error for a malformed (non-numeric) streamId, not a 500', async () => {
+    const res = await request(app)
+      .get('/v1/events/subscribe?streams=not-a-numeric-id')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Invalid subscription parameters');
+    expect(res.body.errors).toBeDefined();
+  });
+
+  it('rejects requests missing authentication', async () => {
+    const res = await request(app).get('/v1/events/subscribe?streams=not-a-numeric-id');
+    expect(res.status).toBe(401);
+  });
+});

--- a/frontend/src/components/Navbar.test.tsx
+++ b/frontend/src/components/Navbar.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('@/context/wallet-context', () => ({
+  useWallet: () => ({ session: null, status: 'disconnected' }),
+}));
+
+vi.mock('./ModeToggle', () => ({
+  ModeToggle: () => <div data-testid="mode-toggle" />,
+}));
+
+vi.mock('./wallet/WalletButton', () => ({
+  WalletButton: () => <button>Connect Wallet</button>,
+}));
+
+vi.mock('./NotificationDropdown', () => ({
+  NotificationDropdown: () => <div data-testid="notification-dropdown" />,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: React.PropsWithChildren<{ href: string }>) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+import { Navbar } from './Navbar';
+
+describe('Navbar mobile menu toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens the mobile menu when the hamburger button is clicked', () => {
+    render(<Navbar />);
+
+    expect(screen.queryByTestId('mobile-menu')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /open menu/i }));
+
+    expect(screen.getByTestId('mobile-menu')).toBeInTheDocument();
+  });
+
+  it('closes the mobile menu when the hamburger button is clicked again', () => {
+    render(<Navbar />);
+
+    fireEvent.click(screen.getByRole('button', { name: /open menu/i }));
+    expect(screen.getByTestId('mobile-menu')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /close menu/i }));
+    expect(screen.queryByTestId('mobile-menu')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,58 +1,91 @@
 "use client";
+import { useState } from "react";
+import { Menu, X } from "lucide-react";
 import { NotificationDropdown } from "./NotificationDropdown";
 import Link from "next/link";
 import { useWallet } from "@/context/wallet-context";
 import { ModeToggle } from "./ModeToggle";
 import { WalletButton } from "./wallet/WalletButton";
 
+const NAV_LINKS = [
+  { href: "/", label: "Home" },
+  { href: "/dashboard", label: "Dashboard" },
+  { href: "/streams/create", label: "Create Stream" },
+  { href: "/settings", label: "Settings" },
+];
+
 export const Navbar = () => {
   const { session, status } = useWallet();
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   return (
-    <nav className="sticky top-0 z-50 flex items-center justify-between px-6 py-4 backdrop-blur-md md:px-12 border-b border-glass-border bg-background/50">
-      <div className="flex items-center gap-2">
-        <div className="h-9 w-9 rounded-xl bg-accent flex items-center justify-center shadow-[0_0_15px_rgba(16,185,129,0.2)]">
-          <svg
-            className="h-6 w-6 text-background"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M13 10V3L4 14h7v7l9-11h-7z"
-            />
-          </svg>
+    <nav className="sticky top-0 z-50 backdrop-blur-md border-b border-glass-border bg-background/50">
+      <div className="flex items-center justify-between px-6 py-4 md:px-12">
+        <div className="flex items-center gap-2">
+          <div className="h-9 w-9 rounded-xl bg-accent flex items-center justify-center shadow-[0_0_15px_rgba(16,185,129,0.2)]">
+            <svg
+              className="h-6 w-6 text-background"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M13 10V3L4 14h7v7l9-11h-7z"
+              />
+            </svg>
+          </div>
+          <span className="text-2xl font-black tracking-tighter text-white">
+            FlowFi
+          </span>
         </div>
-        <span className="text-2xl font-black tracking-tighter text-white">
-          FlowFi
-        </span>
+
+        <div className="hidden items-center gap-8 text-sm font-semibold text-slate-400 md:flex">
+          {NAV_LINKS.map((link) => (
+            <Link key={link.href} href={link.href} className="transition-colors hover:text-accent">
+              {link.label}
+            </Link>
+          ))}
+          <ModeToggle />
+        </div>
+
+        <div className="flex items-center gap-4">
+          {status === "connected" && session?.publicKey && (
+            <NotificationDropdown publicKey={session.publicKey} />
+          )}
+          <WalletButton />
+          <button
+            type="button"
+            aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
+            aria-expanded={isMobileMenuOpen}
+            onClick={() => setIsMobileMenuOpen((open) => !open)}
+            className="md:hidden text-slate-400 hover:text-accent transition-colors"
+          >
+            {isMobileMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+          </button>
+        </div>
       </div>
 
-      <div className="hidden items-center gap-8 text-sm font-semibold text-slate-400 md:flex">
-        <Link href="/" className="transition-colors hover:text-accent">
-          Home
-        </Link>
-        <Link href="/dashboard" className="transition-colors hover:text-accent">
-          Dashboard
-        </Link>
-        <Link href="/streams/create" className="transition-colors hover:text-accent">
-          Create Stream
-        </Link>
-        <Link href="/settings" className="transition-colors hover:text-accent">
-          Settings
-        </Link>
-        <ModeToggle />
-      </div>
-
-      <div className="flex items-center gap-4">
-        {status === "connected" && session?.publicKey && (
-          <NotificationDropdown publicKey={session.publicKey} />
-        )}
-        <WalletButton />
-      </div>
+      {isMobileMenuOpen && (
+        <div
+          data-testid="mobile-menu"
+          className="flex flex-col gap-4 px-6 pb-4 text-sm font-semibold text-slate-400 md:hidden"
+        >
+          {NAV_LINKS.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="transition-colors hover:text-accent"
+              onClick={() => setIsMobileMenuOpen(false)}
+            >
+              {link.label}
+            </Link>
+          ))}
+          <ModeToggle />
+        </div>
+      )}
     </nav>
   );
 };


### PR DESCRIPTION
## Summary
- **#1052**: Added an integration test for `GET /v1/events/subscribe` asserting a malformed/non-numeric `streamId` returns a clean 400 with a descriptive error, not an uncaught 500. Verified RED (temporarily disabled the Zod-error branch, confirmed 500) before confirming GREEN on the existing code — no controller change was needed, the existing Zod catch already handles this correctly.
- **#1051**: Verified `backend/tests/health.test.ts` already provides full contract coverage for `/health` (response shape: status, db, indexerEnabled, indexerLag, uptime) across both the healthy and degraded (indexer-lagging) cases. No new test added since acceptance criteria were already satisfied — flagging this so it doesn't stay open assuming a gap exists.
- **#1053**: `Navbar.tsx` had no mobile menu toggle at all (nav links were `hidden md:flex`, no hamburger). Implemented a hamburger button (lucide `Menu`/`X` icons, `aria-label`/`aria-expanded`) that toggles a `data-testid="mobile-menu"` panel, plus render tests asserting the menu opens on click and closes on a second click.

## Test plan
- [x] `backend/tests/integration/sse-subscribe.test.ts` — new, passes; confirmed it fails (500) if the Zod-error handling is disabled
- [x] `backend/tests/health.test.ts` — pre-existing, already covers full contract
- [x] `frontend/src/components/Navbar.test.tsx` — new, covers open + close toggle behavior

Closes #1052
Closes #1051
Closes #1053