### PR TITLE
fix: improve accessibility and error handling in progress bar, streaming amount, and soroban client

### DIFF
--- a/frontend/src/__tests__/useStreamingAmount.test.tsx
+++ b/frontend/src/__tests__/useStreamingAmount.test.tsx
@@ -85,4 +85,41 @@ describe("useStreamingAmount", () => {
     // Claimable must be capped at 890
     expect(result.current).toBe(890);
   });
+
+  it("pauses recomputation while the tab is hidden and resyncs when visible again", () => {
+    const params = {
+      deposited: 1000,
+      withdrawn: 0,
+      ratePerSecond: 1,
+      startTime: 1000 * 1000 - 100, // started 100 seconds ago
+      isActive: true,
+    };
+
+    const { result } = renderHook((props) => useStreamingAmount(props), {
+      initialProps: params,
+    });
+
+    expect(result.current).toBe(100);
+
+    // Hide the tab and advance time — the displayed value should not tick.
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => true,
+    });
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      vi.advanceTimersByTime(10000);
+    });
+    expect(result.current).toBe(100);
+
+    // Reveal the tab again — the value should resync to the true elapsed time.
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => false,
+    });
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(result.current).toBeCloseTo(110, 1);
+  });
 });

--- a/frontend/src/components/Progressbar.test.tsx
+++ b/frontend/src/components/Progressbar.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ProgressBar from "./Progressbar";
+
+describe("ProgressBar", () => {
+  it("renders the ARIA progressbar attributes reflecting the current value", () => {
+    render(<ProgressBar percentage={42} label="Vested" />);
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "42");
+    expect(bar).toHaveAttribute("aria-valuemin", "0");
+    expect(bar).toHaveAttribute("aria-valuemax", "100");
+    expect(bar).toHaveAttribute("aria-valuetext", "42%");
+    expect(bar).toHaveAttribute("aria-label", "Vested");
+  });
+
+  it("clamps the value and updates the ARIA attributes when props change", () => {
+    const { rerender } = render(<ProgressBar percentage={150} />);
+
+    let bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "100");
+    expect(bar).toHaveAttribute("aria-label", "Progress");
+
+    rerender(<ProgressBar percentage={-10} />);
+    bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "0");
+  });
+});

--- a/frontend/src/components/Progressbar.tsx
+++ b/frontend/src/components/Progressbar.tsx
@@ -29,6 +29,8 @@ export default function ProgressBar({ percentage, label }: ProgressBarProps) {
         aria-valuenow={clamped}
         aria-valuemin={0}
         aria-valuemax={100}
+        aria-valuetext={`${clamped}%`}
+        aria-label={label ?? "Progress"}
         style={{
           width: "100%",
           height: "0.6rem",

--- a/frontend/src/hooks/useStreamingAmount.ts
+++ b/frontend/src/hooks/useStreamingAmount.ts
@@ -46,24 +46,32 @@ export function useStreamingAmount({
       maxClaimable > 0;
     let lastFrameTime = performance.now();
 
-    const nowSeconds = Date.now() / 1000;
-    const streamStartTime = startTime ?? lastUpdateTime ?? nowSeconds;
-    const elapsedSinceStart = Math.max(0, nowSeconds - streamStartTime);
-    const currentPauseDuration =
-      isPaused && pausedAt ? Math.max(0, nowSeconds - pausedAt) : 0;
-    const effectiveElapsed = Math.max(
-      0,
-      elapsedSinceStart - (startTime ? totalPausedDuration : 0) - currentPauseDuration,
-    );
+    const computeClaimable = () => {
+      const nowSeconds = Date.now() / 1000;
+      const streamStartTime = startTime ?? lastUpdateTime ?? nowSeconds;
+      const elapsedSinceStart = Math.max(0, nowSeconds - streamStartTime);
+      const currentPauseDuration =
+        isPaused && pausedAt ? Math.max(0, nowSeconds - pausedAt) : 0;
+      const effectiveElapsed = Math.max(
+        0,
+        elapsedSinceStart - (startTime ? totalPausedDuration : 0) - currentPauseDuration,
+      );
 
-    claimableRef.current = clamp(
-      effectiveElapsed * ratePerSecond,
-      0,
-      maxClaimable,
-    );
+      return clamp(effectiveElapsed * ratePerSecond, 0, maxClaimable);
+    };
+
+    claimableRef.current = computeClaimable();
     setClaimable(claimableRef.current);
 
     const tick = (frameTime: number) => {
+      if (document.hidden) {
+        // Skip recomputation while the tab is backgrounded; just keep
+        // rescheduling so we notice when it becomes visible again.
+        lastFrameTime = frameTime;
+        rafId = requestAnimationFrame(tick);
+        return;
+      }
+
       const deltaSeconds = Math.max(0, (frameTime - lastFrameTime) / 1000);
       lastFrameTime = frameTime;
 
@@ -79,11 +87,24 @@ export function useStreamingAmount({
       }
     };
 
+    const handleVisibilityChange = () => {
+      if (!document.hidden && isStreaming) {
+        // Resync to the true elapsed-time value instead of resuming from a
+        // stale tick, then continue ticking from the corrected value.
+        lastFrameTime = performance.now();
+        claimableRef.current = computeClaimable();
+        setClaimable(claimableRef.current);
+      }
+    };
+
     if (isStreaming) {
       rafId = requestAnimationFrame(tick);
     }
 
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
     return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
       if (rafId !== null) {
         cancelAnimationFrame(rafId);
       }

--- a/frontend/src/lib/soroban.test.ts
+++ b/frontend/src/lib/soroban.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getAccount = vi.fn().mockResolvedValue({});
+const simulateTransaction = vi.fn();
+
+vi.mock("@stellar/stellar-sdk", () => {
+  class Address {
+    constructor(private value: string) {}
+    toScVal() {
+      return this.value;
+    }
+  }
+  class Contract {
+    constructor(private address: string) {}
+    call(method: string, ...args: unknown[]) {
+      return { method, args, address: this.address };
+    }
+  }
+  class TransactionBuilder {
+    constructor() {}
+    addOperation() {
+      return this;
+    }
+    setTimeout() {
+      return this;
+    }
+    build() {
+      return {};
+    }
+  }
+  return {
+    Address,
+    Contract,
+    TransactionBuilder,
+    BASE_FEE: "100",
+    scValToNative: vi.fn(),
+    rpc: {
+      Server: vi.fn().mockImplementation(() => ({
+        getAccount,
+        simulateTransaction,
+      })),
+      Api: {
+        isSimulationError: (result: { error?: unknown }) => Boolean(result?.error),
+      },
+    },
+  };
+});
+
+import { fetchTokenBalance, SorobanCallError } from "./soroban";
+
+describe("soroban RPC error handling", () => {
+  beforeEach(() => {
+    simulateTransaction.mockReset();
+    getAccount.mockResolvedValue({});
+  });
+
+  it("throws a ContractNotFound error when the RPC response indicates a missing contract", async () => {
+    simulateTransaction.mockResolvedValue({
+      error: "HostError: Error(Storage, MissingValue): trying to get non-existing contract instance",
+    });
+
+    await expect(fetchTokenBalance("GABC", "USDC")).rejects.toMatchObject({
+      name: "SorobanCallError",
+      code: "ContractNotFound",
+    });
+
+    try {
+      await fetchTokenBalance("GABC", "USDC");
+      throw new Error("expected fetchTokenBalance to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SorobanCallError);
+      expect((error as SorobanCallError).message).toMatch(/no contract is deployed/i);
+    }
+  });
+
+  it("throws a generic NetworkError for other simulation failures", async () => {
+    simulateTransaction.mockResolvedValue({
+      error: "some unrelated simulation failure",
+    });
+
+    await expect(fetchTokenBalance("GABC", "USDC")).rejects.toMatchObject({
+      name: "SorobanCallError",
+      code: "NetworkError",
+    });
+  });
+});

--- a/frontend/src/lib/soroban.ts
+++ b/frontend/src/lib/soroban.ts
@@ -59,11 +59,36 @@ export class SorobanCallError extends Error {
       | "NotInitialized"
       | "WalletRejected"
       | "NetworkError"
+      | "ContractNotFound"
       | "Unknown",
   ) {
     super(message);
     this.name = "SorobanCallError";
   }
+}
+
+const CONTRACT_NOT_FOUND_PATTERN =
+  /(contract.*(not exist|not found|does not exist))|(missingvalue)|(no contract (code|instance) for)/i;
+
+/**
+ * Detects the specific Soroban RPC response shape that indicates there is no
+ * contract deployed at the configured address, as opposed to a generic
+ * simulation/network failure.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isContractNotFoundError(simResult: any): boolean {
+  const message: string =
+    typeof simResult?.error === "string"
+      ? simResult.error
+      : (simResult?.error?.message ?? "");
+  return CONTRACT_NOT_FOUND_PATTERN.test(message);
+}
+
+function contractNotFoundError(contractAddress: string): SorobanCallError {
+  return new SorobanCallError(
+    `No contract is deployed at address ${contractAddress} on this network. Check that NEXT_PUBLIC_STREAM_CONTRACT_ID (or the relevant token address) is configured correctly for this environment.`,
+    "ContractNotFound",
+  );
 }
 
 export type DurationUnit = "seconds" | "minutes" | "hours" | "days" | "weeks" | "months";
@@ -141,6 +166,9 @@ export async function fetchTokenBalance(
 
   const simResult = await server.simulateTransaction(tx);
   if (rpc.Api?.isSimulationError?.(simResult) ?? simResult?.error) {
+    if (isContractNotFoundError(simResult)) {
+      throw contractNotFoundError(tokenAddress);
+    }
     throw new SorobanCallError(`Failed to fetch token balance: ${simResult.error}`, "NetworkError");
   }
 
@@ -216,6 +244,9 @@ async function freighterCall(
 
   const simResult = await server.simulateTransaction(tx);
   if (rpc.Api?.isSimulationError?.(simResult) ?? simResult?.error) {
+    if (isContractNotFoundError(simResult)) {
+      throw contractNotFoundError(CONTRACT_ID);
+    }
     throw new SorobanCallError(`Simulation failed: ${simResult.error}`, "NetworkError");
   }
 


### PR DESCRIPTION
- **#1121**: Added `aria-label`/`aria-valuetext` to the progress bar in `Progressbar.tsx` (it already had `role="progressbar"` and the `aria-value*` min/now/max attributes), so screen readers announce a description alongside the current progress value.
- **#1120**: Added detection of the Soroban RPC "contract not found at address" response shape (`isContractNotFoundError` in `soroban.ts`) and a dedicated `ContractNotFound` error code with a clear, actionable message, applied to both the token-balance simulation and the general contract-call simulation paths.
- **#1119**: `useStreamingAmount` now listens for `visibilitychange` and skips recomputation while `document.hidden` is true, then resyncs the displayed amount to the true elapsed-time value (instead of resuming from a stale tick) when the tab becomes visible again.

**#1118 **: `useModalDialog.ts` captures `document.activeElement` on open and restores focus to it on close/unmount (see the existing `previouslyFocusedRef` logic and the passing "should restore focus to previously focused element on unmount" test) — no change needed.

## Test plan
- [x] `npx vitest run` for the touched files — all pass (Progressbar, useStreamingAmount, soroban, useModalDialog)
- [x] `npx tsc --noEmit` — no new errors in changed files (two pre-existing unrelated test-file failures in `useIncomingStreams.test.ts` / another `.ts` test using JSX are out of scope)

Closes #1121
Closes #1120
Closes #1119
Closes #1118