### PR TITLE
test: add render coverage for Skeleton.tsx

### DIFF
--- a/frontend/src/components/ui/Skeleton.test.tsx
+++ b/frontend/src/components/ui/Skeleton.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { Skeleton } from "./Skeleton";
+
+// Issue #1032 asks for a render test per exported skeleton *variant*
+// asserting a row-count prop controls the number of rendered placeholder
+// elements (e.g. a StreamListSkeleton with a `rows` prop). As of this
+// change, Skeleton.tsx exports exactly one component — a single
+// className-only placeholder `<div>` with no row-count prop and no other
+// variants (StreamListSkeleton or otherwise) anywhere in the codebase.
+// There is nothing matching that description to test without inventing a
+// multi-variant API that doesn't exist today, so this covers the actual
+// single export instead.
+describe("Skeleton", () => {
+  it("renders a single placeholder element", () => {
+    const { container } = render(<Skeleton />);
+    expect(container.children).toHaveLength(1);
+  });
+
+  it("applies the pulse/placeholder styling by default", () => {
+    const { container } = render(<Skeleton />);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.className).toContain("animate-pulse");
+    expect(el.className).toContain("rounded-md");
+  });
+
+  it("merges a custom className with the default styling", () => {
+    const { container } = render(<Skeleton className="h-4 w-full" />);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.className).toContain("animate-pulse");
+    expect(el.className).toContain("h-4");
+    expect(el.className).toContain("w-full");
+  });
+
+  it("renders with no className without erroring", () => {
+    const { container } = render(<Skeleton />);
+    expect(container.firstElementChild).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Changes

- **#1032**: the issue describes `Skeleton.tsx` exporting several variants with row-count props (plus a mentioned but already-dead `StreamListSkeleton`). As it exists on `main` today, `Skeleton.tsx` exports exactly one component — a single `className`-only placeholder `<div>`, no row-count prop, no `StreamListSkeleton` or any other named variant anywhere in the codebase (checked with a repo-wide grep). There's nothing matching the multi-variant "assert placeholder count equals the row prop" description to test without inventing that API from scratch, which would be adding a feature, not testing one that exists.
- Added `Skeleton.test.tsx` covering the one export that does exist: renders exactly one placeholder element, applies the default `animate-pulse`/`rounded-md` styling, and correctly merges a caller-supplied `className`.

## Test plan

- [x] `npx vitest run src/components/ui/Skeleton.test.tsx` — 4 passed
- [x] `npx vitest run` (full suite) — 186 passed; the 2 pre-existing failing suites (`useIncomingStreams.test.ts` and one other, both a `.ts`-file-using-JSX esbuild error) fail identically on `main` before this change, confirmed via `git stash -u` — unrelated to this change, out of scope

Closes #1032