### PR TITLE
fix: timeout hung stream fetches, backoff SSE reconnects, testable polling, UTC dates

### DIFF
--- a/frontend/src/__tests__/dashboard.test.ts
+++ b/frontend/src/__tests__/dashboard.test.ts
@@ -79,4 +79,22 @@ describe("mapBackendStreamToFrontend", () => {
       expect(mapBackendStreamToFrontend(s, "G").status).toBe("Completed");
     });
   });
+
+  describe("date", () => {
+    it("formats startTime as a UTC calendar date, independent of the runner's local timezone", () => {
+      // 2023-11-14T22:13:20.000Z: in a negative UTC-offset local timezone this
+      // instant falls on the previous local calendar day, which is exactly
+      // the ambiguity this format must avoid.
+      const s = makeStream({ startTime: 1_700_000_000 });
+      expect(mapBackendStreamToFrontend(s, "G").date).toBe("2023-11-14");
+    });
+
+    it("is stable across different timestamps within the same UTC day", () => {
+      const morning = makeStream({ startTime: 1_700_000_000 }); // 22:13:20 UTC
+      const lateSameUtcDay = makeStream({ startTime: 1_700_003_000 }); // 23:03:20 UTC
+      expect(mapBackendStreamToFrontend(morning, "G").date).toBe(
+        mapBackendStreamToFrontend(lateSameUtcDay, "G").date,
+      );
+    });
+  });
 });

--- a/frontend/src/__tests__/useStreamEvents.test.tsx
+++ b/frontend/src/__tests__/useStreamEvents.test.tsx
@@ -152,6 +152,86 @@ describe('useStreamEvents', () => {
     expect(MockEventSource.instance).not.toBeNull();
   });
 
+  it('grows the reconnect delay exponentially across consecutive failures', () => {
+    // Keep `streamIds` referentially stable across re-renders (an inline
+    // array literal would change identity on every render and cause the
+    // hook to reconnect on its own, independent of the backoff timer).
+    const streamIds = ['1'];
+    renderHook(() =>
+      useStreamEvents({ streamIds, autoReconnect: true, maxRetryDelay: 30000 }),
+    );
+
+    const first = MockEventSource.instance;
+    act(() => { first?.triggerError(); });
+
+    // First retry is scheduled after the initial 1000ms delay.
+    act(() => { vi.advanceTimersByTime(999); });
+    expect(MockEventSource.instance).toBe(first);
+    act(() => { vi.advanceTimersByTime(1); });
+    const second = MockEventSource.instance;
+    expect(second).not.toBe(first);
+    expect(second).not.toBeNull();
+
+    act(() => { second?.triggerError(); });
+
+    // Second retry should wait ~2000ms (doubled), not repeat the 1000ms delay.
+    act(() => { vi.advanceTimersByTime(1999); });
+    expect(MockEventSource.instance).toBe(second);
+    act(() => { vi.advanceTimersByTime(1); });
+    const third = MockEventSource.instance;
+    expect(third).not.toBe(second);
+    expect(third).not.toBeNull();
+
+    act(() => { third?.triggerError(); });
+
+    // Third retry should wait ~4000ms.
+    act(() => { vi.advanceTimersByTime(3999); });
+    expect(MockEventSource.instance).toBe(third);
+    act(() => { vi.advanceTimersByTime(1); });
+    expect(MockEventSource.instance).not.toBe(third);
+  });
+
+  it('caps the reconnect delay at maxRetryDelay', () => {
+    const streamIds = ['1'];
+    renderHook(() =>
+      useStreamEvents({ streamIds, autoReconnect: true, maxRetryDelay: 1500 }),
+    );
+
+    const first = MockEventSource.instance;
+    act(() => { first?.triggerError(); });
+    act(() => { vi.advanceTimersByTime(1000); }); // capped delay is min(1000, 1500) = 1000
+    const second = MockEventSource.instance;
+    expect(second).not.toBe(first);
+
+    act(() => { second?.triggerError(); });
+    // Next delay would be 2000 uncapped, but maxRetryDelay caps it at 1500.
+    act(() => { vi.advanceTimersByTime(1499); });
+    expect(MockEventSource.instance).toBe(second);
+    act(() => { vi.advanceTimersByTime(1); });
+    expect(MockEventSource.instance).not.toBe(second);
+  });
+
+  it('resets the backoff delay to the initial value after a successful connection', () => {
+    const streamIds = ['1'];
+    renderHook(() =>
+      useStreamEvents({ streamIds, autoReconnect: true, maxRetryDelay: 30000 }),
+    );
+
+    const first = MockEventSource.instance;
+    act(() => { first?.triggerError(); });
+    act(() => { vi.advanceTimersByTime(1000); }); // reconnect after initial 1000ms
+
+    const second = MockEventSource.instance;
+    act(() => { second?.open(); }); // successful connection resets the counter
+    act(() => { second?.triggerError(); });
+
+    // Backoff should restart at 1000ms, not continue growing to 2000ms.
+    act(() => { vi.advanceTimersByTime(999); });
+    expect(MockEventSource.instance).toBe(second);
+    act(() => { vi.advanceTimersByTime(1); });
+    expect(MockEventSource.instance).not.toBe(second);
+  });
+
   it('clearEvents empties the events array', () => {
     const { result } = renderHook(() =>
       useStreamEvents({ streamIds: ['1'], autoReconnect: false }),

--- a/frontend/src/hooks/useIncomingStreams.test.tsx
+++ b/frontend/src/hooks/useIncomingStreams.test.tsx
@@ -7,8 +7,9 @@ import {
   useWithdrawIncomingStream,
   incomingStreamsQueryKey,
 } from "./useIncomingStreams";
-import { fetchIncomingStreams } from "@/lib/api/streams";
+import { fetchIncomingStreams, type IncomingStreamRecord } from "@/lib/api/streams";
 import { withdrawFromStream } from "@/lib/soroban";
+import type { WalletSession } from "@/lib/wallet";
 
 vi.mock("@/lib/api/streams", () => ({
   fetchIncomingStreams: vi.fn(),
@@ -64,6 +65,37 @@ describe("useIncomingStreams hooks", () => {
       expect(result.current.fetchStatus).toBe("idle");
       expect(fetchIncomingStreams).not.toHaveBeenCalled();
     });
+
+    it("does not poll by default", async () => {
+      vi.useFakeTimers();
+      vi.mocked(fetchIncomingStreams).mockResolvedValue([]);
+
+      renderHook(() => useIncomingStreams("pubkey"), { wrapper });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+
+      expect(fetchIncomingStreams).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    it("polls at the provided refetchInterval when overridden", async () => {
+      vi.useFakeTimers();
+      vi.mocked(fetchIncomingStreams).mockResolvedValue([]);
+
+      renderHook(
+        () => useIncomingStreams("pubkey", { refetchInterval: 5000 }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+
+      expect(vi.mocked(fetchIncomingStreams).mock.calls.length).toBeGreaterThan(1);
+      vi.useRealTimers();
+    });
   });
 
   describe("useWithdrawIncomingStream", () => {
@@ -74,17 +106,17 @@ describe("useIncomingStreams hooks", () => {
       );
 
       await expect(
-        result.current.mutateAsync({} as any)
+        result.current.mutateAsync({} as unknown as IncomingStreamRecord)
       ).rejects.toThrow("Please connect your wallet first");
       expect(withdrawFromStream).not.toHaveBeenCalled();
     });
 
     it("invalidates incomingStreamsQueryKey(publicKey) on success", async () => {
-      (withdrawFromStream as any).mockResolvedValue({ status: "success" });
-      (fetchIncomingStreams as any).mockResolvedValue([]);
-      
+      vi.mocked(withdrawFromStream).mockResolvedValue({ success: true, txHash: "tx-hash" });
+      vi.mocked(fetchIncomingStreams).mockResolvedValue([]);
+
       const { result } = renderHook(
-        () => useWithdrawIncomingStream({} as any, "pubkey"),
+        () => useWithdrawIncomingStream({} as unknown as WalletSession, "pubkey"),
         { wrapper }
       );
 
@@ -92,14 +124,14 @@ describe("useIncomingStreams hooks", () => {
 
       await act(async () => {
         await result.current.mutateAsync({
-          id: 1,
+          id: "1",
           streamId: 1,
           withdrawn: 0,
           deposited: 100,
           ratePerSecond: 1,
           isPaused: false,
           lastUpdateTime: Date.now() / 1000,
-        } as any);
+        } as unknown as IncomingStreamRecord);
       });
 
       // Wait for pollIndexerForWithdraw to complete and call invalidateQueries

--- a/frontend/src/hooks/useIncomingStreams.ts
+++ b/frontend/src/hooks/useIncomingStreams.ts
@@ -17,11 +17,24 @@ export function incomingStreamsQueryKey(publicKey: string | null | undefined) {
   return ["incoming-streams", publicKey] as const;
 }
 
-export function useIncomingStreams(publicKey: string | null | undefined) {
+// Current production behavior: no automatic polling. Tests can override this
+// via `options.refetchInterval` instead of having to mock timers globally.
+const DEFAULT_INCOMING_STREAMS_REFETCH_INTERVAL: number | false = false;
+
+export interface UseIncomingStreamsOptions {
+  refetchInterval?: number | false;
+}
+
+export function useIncomingStreams(
+  publicKey: string | null | undefined,
+  options?: UseIncomingStreamsOptions,
+) {
   return useQuery({
     queryKey: incomingStreamsQueryKey(publicKey),
     queryFn: () => fetchIncomingStreams(publicKey!),
     enabled: Boolean(publicKey),
+    refetchInterval:
+      options?.refetchInterval ?? DEFAULT_INCOMING_STREAMS_REFETCH_INTERVAL,
   });
 }
 

--- a/frontend/src/hooks/useStreamEvents.ts
+++ b/frontend/src/hooks/useStreamEvents.ts
@@ -108,13 +108,14 @@ export function useStreamEvents(
 
       if (autoReconnect) {
         setReconnecting(true);
+        // Cap the delay we're about to wait on, and precompute the next
+        // (doubled, capped) delay up front so consecutive failures keep
+        // growing the backoff even if the next attempt fails immediately.
+        const delay = Math.min(retryDelayRef.current, maxRetryDelay);
+        retryDelayRef.current = Math.min(retryDelayRef.current * 2, maxRetryDelay);
         reconnectTimeoutRef.current = setTimeout(() => {
           connectRef.current();
-          retryDelayRef.current = Math.min(
-            retryDelayRef.current * 2,
-            maxRetryDelay
-          );
-        }, retryDelayRef.current);
+        }, delay);
       }
     };
   }, [buildUrl, autoReconnect, maxRetryDelay]);

--- a/frontend/src/lib/api/_shared.ts
+++ b/frontend/src/lib/api/_shared.ts
@@ -2,12 +2,49 @@ const DEFAULT_API_BASE_URL = "http://localhost:3001";
 
 export const STROOPS_DIVISOR = 1e7;
 
+/** Default timeout applied by `fetchWithTimeout` when the caller doesn't override it. */
+export const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+
+/** Thrown by `fetchWithTimeout` when a request is aborted for exceeding its timeout. */
+export class FetchTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Request timed out after ${timeoutMs}ms`);
+    this.name = "FetchTimeoutError";
+  }
+}
+
 export function getApiBaseUrl(): string {
   return (process.env.NEXT_PUBLIC_API_URL ?? DEFAULT_API_BASE_URL).replace(/\/+$/, "");
 }
 
 export function toTokenAmount(raw: string): number {
   return Number.parseFloat(raw) / STROOPS_DIVISOR;
+}
+
+/**
+ * Shared fetch wrapper that aborts the request after `timeoutMs` so a stalled
+ * backend or indexer can't hang the caller's loading state indefinitely.
+ * Rejects with a `FetchTimeoutError` (a clear, user-presentable message) when
+ * the timeout fires instead of the browser's generic abort error.
+ */
+export async function fetchWithTimeout(
+  input: string,
+  init: RequestInit = {},
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new FetchTimeoutError(timeoutMs);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 export function getStreamsEndpointCandidates(): string[] {

--- a/frontend/src/lib/api/streams.test.ts
+++ b/frontend/src/lib/api/streams.test.ts
@@ -166,4 +166,28 @@ describe('fetchIncomingStreams', () => {
       /Endpoint not found:/
     );
   });
+
+  it('aborts a hung request after the timeout and surfaces a clear error', async () => {
+    vi.useFakeTimers();
+
+    // Simulate a backend that never responds: fetch only settles when the
+    // AbortController tied to the timeout fires.
+    fetchMock.mockImplementation((_url: string, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const abortError = new Error('The operation was aborted.');
+          abortError.name = 'AbortError';
+          reject(abortError);
+        });
+      });
+    });
+
+    const pending = fetchIncomingStreams(recipientPublicKey, 5000);
+    const assertion = expect(pending).rejects.toThrow(/timed out after 5000ms/);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await assertion;
+
+    vi.useRealTimers();
+  });
 });

--- a/frontend/src/lib/api/streams.ts
+++ b/frontend/src/lib/api/streams.ts
@@ -1,7 +1,12 @@
 import type { BackendStream } from "@/lib/api-types";
 import { TOKEN_ADDRESSES } from "@/lib/soroban";
 import { shortenPublicKey } from "@/lib/wallet";
-import { getStreamsEndpointCandidates, toTokenAmount } from "@/lib/api/_shared";
+import {
+  DEFAULT_FETCH_TIMEOUT_MS,
+  fetchWithTimeout,
+  getStreamsEndpointCandidates,
+  toTokenAmount,
+} from "@/lib/api/_shared";
 
 export type IncomingStreamStatus = "Active" | "Paused" | "Completed";
 
@@ -65,6 +70,7 @@ function mapBackendStream(stream: BackendStream): IncomingStreamRecord {
 
 export async function fetchIncomingStreams(
   recipientPublicKey: string,
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
 ): Promise<IncomingStreamRecord[]> {
   const endpoints = getStreamsEndpointCandidates();
   const params = new URLSearchParams({
@@ -76,7 +82,7 @@ export async function fetchIncomingStreams(
   let lastError: Error | null = null;
 
   for (const endpoint of endpoints) {
-    const response = await fetch(`${endpoint}?${params.toString()}`);
+    const response = await fetchWithTimeout(`${endpoint}?${params.toString()}`, {}, timeoutMs);
 
     if (response.ok) {
       const payload = (await response.json()) as BackendStream[] | StreamListResponse;

--- a/frontend/src/lib/dashboard.ts
+++ b/frontend/src/lib/dashboard.ts
@@ -46,6 +46,19 @@ export interface DashboardAnalyticsMetric {
   unavailableText: string;
 }
 
+/**
+ * Timezone display strategy for this file: all stream dates are displayed in
+ * UTC rather than the viewer's local timezone. FlowFi streams have a single
+ * canonical start time; formatting it locally would make two recipients in
+ * different timezones see different displayed dates/durations for the same
+ * stream, which is confusing for a payment-streaming product. Every date
+ * formatting helper below must go through `formatStreamDateUtc` so this stays
+ * consistent as more date fields are added.
+ */
+function formatStreamDateUtc(unixTimestampSeconds: number): string {
+  return new Date(unixTimestampSeconds * 1000).toISOString().split("T")[0] ?? "";
+}
+
 function shortenAddress(address: string): string {
   if (!address || address.length < 10) return address;
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
@@ -88,21 +101,19 @@ async function fetchStreams(
   for (const endpoint of endpoints) {
     try {
       const response = await fetch(`${endpoint}?${params.toString()}`, { signal });
-    if (response.ok) {
-      const payload = (await response.json()) as
-        | BackendStream[]
-        | { data?: BackendStream[] };
-      return Array.isArray(payload) ? payload : payload.data ?? [];
-    }
+      if (response.ok) {
+        const payload = (await response.json()) as
+          | BackendStream[]
+          | { data?: BackendStream[] };
+        return Array.isArray(payload) ? payload : payload.data ?? [];
+      }
 
-    if (response.status === 404) {
-      lastError = new Error(`Endpoint not found: ${endpoint}`);
-      continue;
-    }
+      if (response.status === 404) {
+        lastError = new Error(`Endpoint not found: ${endpoint}`);
+        continue;
+      }
 
-    lastError = new Error(`Failed to fetch streams (${response.status}) from ${endpoint}`);
-  }
-
+      lastError = new Error(`Failed to fetch streams (${response.status}) from ${endpoint}`);
     } catch (err) {
       if (err instanceof Error && err.name === "AbortError") {
         throw err;
@@ -130,7 +141,7 @@ export function mapBackendStreamToFrontend(s: BackendStream, counterparty: strin
     status: mapStreamStatus(s),
     deposited,
     withdrawn,
-    date: new Date(s.startTime * 1000).toISOString().split("T")[0] ?? "",
+    date: formatStreamDateUtc(s.startTime),
     ratePerSecond,
     lastUpdateTime: s.lastUpdateTime,
     isActive: s.isActive,


### PR DESCRIPTION
## #1042 — lib/api/streams.ts has no timeout on its fetch calls

Added a shared `fetchWithTimeout` wrapper in `lib/api/_shared.ts` (AbortController-based, configurable `timeoutMs`, default 10s) and switched `fetchIncomingStreams` to use it instead of a bare `fetch`. A stalled backend now rejects with a `FetchTimeoutError` carrying a clear message ("Request timed out after Xms") instead of leaving the query pending forever; this message already surfaces in the incoming-streams UI via the existing `query.error.message` error path.

## #1041 — useStreamEvents.ts has no exponential backoff after repeated reconnect failures

Reworked the reconnect scheduling so the next (doubled, capped) delay is computed up front, before the retry timer is scheduled, so the backoff reliably grows across consecutive SSE failures instead of only doubling lazily inside the timeout callback. The delay still resets to its initial value on a successful connection.

## #1040 — useIncomingStreams.ts refetch interval is hardcoded and cannot be disabled for tests

`useIncomingStreams` now accepts an optional second `options` argument with `refetchInterval`. Default behavior is unchanged (no polling); tests (or future call sites) can now pass an explicit interval instead of needing to globally mock timers.

## #1043 — lib/dashboard.ts date formatting uses the browser's local timezone with no explicit UTC handling

Extracted the stream date formatting into a documented `formatStreamDateUtc` helper with a comment explaining the strategy: always display in UTC so two viewers in different timezones see the same date for the same stream. The one date-formatting call site in this file now goes through it.

Also fixes two small pre-existing bugs uncovered while touching these files (both silently broke `tsc`/lint/vitest for the files involved, unrelated to the behavior above, no behavior change):
- `dashboard.ts`: a mismatched brace in `fetchStreams`'s try/catch block.
- `useIncomingStreams.test.ts` contained JSX but had a `.ts` extension; renamed to `.tsx`.

## Test plan

- [x] `npx vitest run` — all tests pass except one pre-existing, unrelated failure (`useWithdrawIncomingStream > invalidates incomingStreamsQueryKey(publicKey) on success`, which uses real timers against a slow exponential poll and was already broken before this PR, just previously masked by the `.ts`/`.tsx` transform bug above)
- [x] `npx eslint` clean on all changed files
- [x] New tests: hung-fetch timeout in `streams.test.ts`, growing/capped/reset backoff delay in `useStreamEvents.test.tsx`, default vs. overridden `refetchInterval` in `useIncomingStreams.test.tsx`, UTC date stability in `dashboard.test.ts`

Closes #1040
Closes #1041
Closes #1042
Closes #1043