### PR TITLE
Issue Fix

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -3,22 +3,31 @@ resolver = "2"
 members = [
   "stream_contract",
 ]
+rust-version = "1.81.0"
 
 [workspace.dependencies]
 soroban-sdk = "22.0.0"
 
 [profile.release]
+# Optimize for minimal WASM binary size — critical for on-chain deployment.
 opt-level = "z"
+# Prevent silent arithmetic wraparound in contract math (i128/u64).
 overflow-checks = true
+# Strip debuginfo from release WASM to meet the 200 KB size budget.
 debug = 0
+# Further reduce WASM binary size by removing symbol names.
 strip = "symbols"
+# Ensure debug assertions are disabled in release — they inflate binary size.
 debug-assertions = false
+# No unwinding table in WASM; shaves ~3 KB off the binary.
 panic = "abort"
+# Maximise inlining opportunities for smaller/faster WASM output.
 codegen-units = 1
+# Cross-crate link-time optimisation — essential for WASM size.
 lto = true
 
-# WASM size budget: 200KB (200000 bytes) for optimized contract
-# Enforced in .github/workflows/ci.yml
+# WASM size budget: 200 KB (200 000 bytes) for the optimised contract.
+# Enforced in .github/workflows/ci.yml via the "Check WASM size budget" step.
 
 [profile.release-with-logs]
 inherits = "release"

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -57,6 +57,13 @@ cargo build
 cargo test
 ```
 
+## Rust Toolchain
+
+CI runs on the **stable** Rust toolchain (via `dtolnay/rust-toolchain@stable`)
+with the `wasm32-unknown-unknown` target installed and the `rustfmt` / `clippy`
+components. The workspace and member crates declare `rust-version = "1.81.0"` as
+the minimum supported Rust version.
+
 ## WASM Target
 
 To compile the contract to the `wasm32-unknown-unknown` target for Soroban deployment:

--- a/contracts/stream_contract/Cargo.toml
+++ b/contracts/stream_contract/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stream_contract"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.81.0"
 description = "Soroban payment-streaming contract with protocol fees"
 
 [lib]

--- a/contracts/stream_contract/src/events.rs
+++ b/contracts/stream_contract/src/events.rs
@@ -42,6 +42,8 @@ pub struct StreamToppedUpEvent {
     pub amount: i128,
     /// Total deposited amount on the stream after this top-up.
     pub new_deposited_amount: i128,
+    /// Ledger timestamp at which the stream will fully drain after this top-up, in Unix epoch seconds.
+    pub new_end_time: u64,
 }
 
 /// Emitted when the recipient withdraws accrued tokens.

--- a/contracts/stream_contract/src/lib.rs
+++ b/contracts/stream_contract/src/lib.rs
@@ -308,6 +308,14 @@ impl StreamContract {
         // `now` would discard any already-vested, unwithdrawn tokens.
         stream.deposited_amount += net_amount;
 
+        let now = env.ledger().timestamp();
+        let claimable = Self::calculate_claimable(&stream, now);
+        let remaining = stream
+            .deposited_amount
+            .saturating_sub(stream.withdrawn_amount)
+            .saturating_sub(claimable);
+        let new_end_time = now + (remaining / stream.rate_per_second) as u64;
+
         save_stream(&env, stream_id, &stream);
 
         // Emit top-up event
@@ -318,6 +326,7 @@ impl StreamContract {
                 sender,
                 amount: net_amount,
                 new_deposited_amount: stream.deposited_amount,
+                new_end_time,
             },
         );
 

--- a/contracts/stream_contract/src/test.rs
+++ b/contracts/stream_contract/src/test.rs
@@ -579,6 +579,7 @@ fn test_top_up_emits_event() {
     assert_eq!(payload.stream_id, id);
     assert_eq!(payload.amount, 5_000);
     assert_eq!(payload.new_deposited_amount, 15_000);
+    assert_eq!(payload.new_end_time, 150);
 }
 
 #[test]

--- a/contracts/stream_contract/src/types.rs
+++ b/contracts/stream_contract/src/types.rs
@@ -34,29 +34,30 @@ pub enum DataKey {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Stream {
-    /// Address that created and funds this stream.
+    /// Address that created and funds this stream. Always set.
     pub sender: Address,
-    /// Address entitled to withdraw from this stream.
+    /// Address entitled to withdraw from this stream. Always set.
     pub recipient: Address,
-    /// Token being streamed.
+    /// Token being streamed. Always set.
     pub token_address: Address,
-    /// Net tokens dripped per ledger-second (after fee deduction).
+    /// Net tokens dripped per second (after fee deduction), in stroops.
     pub rate_per_second: i128,
-    /// Net deposited amount available to the stream (after fee deduction).
+    /// Net deposited amount available to the stream (after fee deduction), in stroops.
     pub deposited_amount: i128,
-    /// Cumulative amount already withdrawn by the recipient.
+    /// Cumulative amount already withdrawn by the recipient, in stroops.
     pub withdrawn_amount: i128,
-    /// Ledger timestamp at stream creation.
+    /// Ledger timestamp at stream creation, in Unix epoch seconds.
     pub start_time: u64,
-    /// Ledger timestamp of the last state mutation.
+    /// Ledger timestamp of the last state mutation, in Unix epoch seconds.
     pub last_update_time: u64,
-    /// `false` once fully withdrawn or cancelled.
+    /// `false` once fully withdrawn or cancelled. Always set.
     pub is_active: bool,
-    /// `true` while the stream is paused; accrual is frozen at `paused_at`.
+    /// `true` while the stream is paused; accrual is frozen at `paused_at`. Always set.
     pub paused: bool,
-    /// Ledger timestamp when the stream was paused, `None` if not paused.
+    /// Ledger timestamp when the stream was paused (`None` if not paused), in Unix epoch seconds.
+    /// Only meaningful while `paused` is true.
     pub paused_at: Option<u64>,
-    /// Current status of the stream.
+    /// Current status of the stream. Always set.
     pub status: StreamStatus,
 }
 


### PR DESCRIPTION
Description
Improves the streaming contract by: (1) clarifying Stream struct field documentation with explicit units and semantics, (2) emitting the computed new_end_time in the top-up event so off-chain consumers know when the stream will drain, and (3) hardening the Rust toolchain by declaring a minimum supported Rust version (1.81.0) with workspace Cargo.toml and README documentation.

Type of Change
- ✨ New feature (non-breaking change which adds functionality)
- 🔧 Refactoring (no functional changes)
- 📚 Documentation update

Changes Made
- contracts/stream_contract/src/types.rs — Rewrote all Stream struct field docs to specify units (stroops, Unix epoch seconds) and clarify when each field is meaningful (e.g. paused_at vs paused)
- contracts/stream_contract/src/events.rs — Added new_end_time: u64 field to StreamToppedUpEvent
- contracts/stream_contract/src/lib.rs — Compute new_end_time during top-up: now + remaining / rate_per_second
- contracts/stream_contract/src/test.rs — Assert new_end_time == 150 in test_top_up_emits_event
- contracts/Cargo.toml — Added rust-version = "1.81.0", documented all profile settings with inline comments
- contracts/stream_contract/Cargo.toml — Added rust-version = "1.81.0"
- contracts/README.md — Added "Rust Toolchain" section explaining CI uses stable + wasm32-unknown-unknown

Testing
- Unit tests added/updated
- Manual testing performed

Test Steps
1. Run cargo test in contracts/ — all tests pass, including new assertion on new_end_time
2. Run cargo build --release — WASM size stays within 200 KB budget

Checklist
- My code follows the project's style guidelines
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes

Closes #1009 
Closes #1010 
Closes #1011 