### PR TITLE
docs: Add dedicated conduct@labscrypt.org enforcement contact (#1089)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -62,10 +62,12 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement on Telegram at
-**https://t.me/+DOylgFv1jyJlNzM0**.
+reported directly to the LabsCrypt moderation team via email at
+**conduct@labscrypt.org** or privately through the [FlowFi Community Telegram](https://t.me/+DOylgFv1jyJlNzM0).
 
-All complaints will be reviewed and investigated promptly and fairly.
+For security vulnerabilities or overlapping security incidents, please refer to our [Security Policy](SECURITY.md) to submit a report through GitHub Private Security Advisories.
+
+All complaints will be reviewed and investigated promptly and fairly by LabsCrypt community leads.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -110,6 +110,8 @@ For security-related questions or concerns that are not vulnerabilities, you can
 - Reach out to the maintainers through GitHub
 - Join our community discussions
 
+For Code of Conduct violations or community safety concerns, please refer to our [Code of Conduct](CODE_OF_CONDUCT.md) or email **conduct@labscrypt.org**.
+
 ## Acknowledgments
 
 We thank the security research community for helping keep FlowFi and our users safe. Contributors who responsibly disclose vulnerabilities will be acknowledged in our security advisories and release notes.


### PR DESCRIPTION
Closes #1089

## Overview
Resolves #1089 by adding a dedicated, monitored enforcement email channel (`conduct@labscrypt.org`) in `CODE_OF_CONDUCT.md` and cross-referencing it from `SECURITY.md`.

## Key Changes
- **`CODE_OF_CONDUCT.md`**: Added `conduct@labscrypt.org` as the primary monitored reporting contact alongside private community channels and Security Policy cross-linking.
- **`SECURITY.md`**: Added a cross-reference in the `Contact` section linking to `CODE_OF_CONDUCT.md` and `conduct@labscrypt.org` for non-vulnerability community safety issues.

## Verification
- Verified documentation layout and cross-file Markdown link accuracy.
