### PR TITLE
feat: add Vercel ignoreCommand to skip frontend builds on unrelated c…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,5 @@
   "installCommand": "npm install",
   "buildCommand": "npm run build --workspace=frontend",
   "devCommand": "npm run dev --workspace=frontend",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- frontend/"
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- frontend/ package.json package-lock.json vercel.json"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,6 @@
   "framework": "nextjs",
   "installCommand": "npm install",
   "buildCommand": "npm run build --workspace=frontend",
-  "devCommand": "npm run dev --workspace=frontend"
+  "devCommand": "npm run dev --workspace=frontend",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- frontend/"
 }


### PR DESCRIPTION

## Summary

Adds `ignoreCommand` to `vercel.json` to prevent unnecessary Vercel frontend builds when changes only affect backend or contracts.

Closes #1080

## Changes

- Added:
```json
"ignoreCommand": "git diff --quiet HEAD^ HEAD -- frontend/"
```

## Behavior
- Skips Vercel builds when no files inside frontend/ are changed.
- Continues normal builds when frontend files are modified.
- 
## Verification
- Confirmed repo is a monorepo with separate frontend, backend, and contracts workspaces.
- No existing ignoreCommand was configured.
- No changes made to build/install commands.