### PR TITLE
fix(frontend): guard against SSR/hydration mismatch in theme provider

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -59,9 +59,50 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // suppressHydrationWarning allows the blocking inline script in <head> to
+  // mutate the `dark` class on <html> without React logging a hydration
+  // mismatch warning. See theme-provider.tsx for the full strategy.
   return (
-    <html lang="en" suppressHydrationWarning> {/* TODO: revisit if i18n is introduced */}
-      <head />
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        {/*
+          Blocking inline script that reads the user's stored theme preference
+          from localStorage and applies the `dark` class to <html> BEFORE the
+          browser paints a single pixel. This prevents the flash-of-wrong-theme
+          (FART) when the server renders a default theme class that differs from
+          the user's persisted preference.
+
+          The `suppressHydrationWarning` prop on <html> is the companion measure:
+          after this script mutates the class, React will see a mismatch between
+          server-rendered <html> (no `dark` class) and the client DOM (possibly
+          `dark` class) and would normally emit a console warning.
+          suppressHydrationWarning tells React to skip that check for this
+          element because the discrepancy is intentional and resolved before
+          hydration completes.
+
+          Flow: inline script runs → class set → browser paints → React hydrates
+          (suppressHydrationWarning) → next-themes ThemeProvider takes over.
+        */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  var theme = localStorage.getItem('flowfi-theme') || 'dark';
+                  if (theme === 'system') {
+                    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                  }
+                  if (theme === 'dark') {
+                    document.documentElement.classList.add('dark');
+                  } else {
+                    document.documentElement.classList.remove('dark');
+                  }
+                } catch (e) {}
+              })();
+            `,
+          }}
+        />
+      </head>
       <body className={`${sora.variable} ${mono.variable} antialiased`}>
         <ThemeProvider
           attribute="class"

--- a/frontend/src/context/theme-provider.tsx
+++ b/frontend/src/context/theme-provider.tsx
@@ -3,6 +3,53 @@
 import * as React from "react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 
+/**
+ * Thin wrapper around `next-themes`' `ThemeProvider` that centralises theme
+ * configuration for the FlowFi frontend.
+ *
+ * ## SSR / Hydration Strategy
+ *
+ * Theme selection is inherently a client-side concern (it depends on
+ * `localStorage` and/or `matchMedia`). The server cannot know which theme the
+ * user prefers, so it always renders a default (`dark`) theme class. This
+ * creates two problems:
+ *
+ * 1. **Flash of wrong theme (FART).** If the user chose "light" previously,
+ *    the browser paints the dark theme first, then swaps to light when
+ *    React hydrates — an unpleasant flicker.
+ *
+ * 2. **Hydration mismatch warning.** When React hydrates the `<html>` element
+ *    and sees that the client DOM has a `dark` class the server did not
+ *    produce, it logs a console warning.
+ *
+ * We solve both problems with a two-part approach inside `layout.tsx`:
+ *
+ * - **Blocking inline `<script>` in `<head>`** — reads `flowfi-theme` from
+ *   localStorage and synchronously adds/removes the `dark` class on
+ *   `<html>` **before the first paint**. No flicker occurs because the
+ *   correct class is present from the very first rendered frame.
+ *
+ * - **`suppressHydrationWarning` on `<html>`** — tells React to skip the
+ *   hydration-difference check for the `<html>` element because we
+ *   intentionally mutate its class list before hydration.
+ *
+ * After hydration, this `ThemeProvider` (via `next-themes`) takes over theme
+ * management, reacting to `useTheme()` calls and persisting changes to the
+ * same `flowfi-theme` localStorage key.
+ *
+ * ## Configuration
+ *
+ * - `attribute="class"` — toggles a `dark` class on `<html>`, which Tailwind
+ *   uses for its `dark:` variant.
+ * - `defaultTheme="dark"` — what the server (and users without any stored
+ *   preference) will see.
+ * - `enableSystem={true}` — when theme is set to `"system"`, the provider
+ *   follows the OS-level `prefers-color-scheme` media query.
+ * - `storageKey="flowfi-theme"` — namespaced localStorage key to avoid
+ *   collisions with other apps on the same origin.
+ * - `disableTransitionOnChange` — prevents a brief CSS transition when the
+ *   theme class changes, making the switch feel instant.
+ */
 export function ThemeProvider({
   children,
   ...props


### PR DESCRIPTION
## Summary

Closes #1083

This PR adds a blocking inline script that reads the user's stored theme preference from `localStorage` and applies the `dark` class to `<html>` **before the browser paints a single pixel**. This prevents the flash-of-wrong-theme (FART) when the server renders a default theme class that differs from the user's persisted preference.

## Problem

`theme-provider.tsx` wraps `next-themes`' `ThemeProvider`, which runs as a client component. In Next.js 16 + React 19, the script injected by `next-themes` via portal may not be truly blocking — it runs after React hydrates, causing:

1. **Flash of wrong theme:** If the user previously chose `light` and the server renders `dark`, the browser paints dark first, then swaps to light.
2. **Hydration mismatch warning:** React sees that the client DOM has a different `dark` class on `<html>` than what the server produced.

## Solution

**Two-part approach inside `layout.tsx`:**

- **Blocking inline `<script>` in `<head>`** — reads `flowfi-theme` from localStorage and synchronously adds/removes the `dark` class on `<html>` before the first paint. Handles `dark`, `light`, and `system` (via `matchMedia`) preferences. No flicker occurs because the correct class is present from the very first rendered frame.
- **`suppressHydrationWarning` on `<html>`** (already present) — tells React to skip the hydration-difference check for this element because we intentionally mutate its class list before hydration.

**Added comprehensive documentation:**

- `theme-provider.tsx`: Full JSDoc block explaining the SSR/hydration strategy and all configuration options.
- `layout.tsx`: Inline comments explaining both the `suppressHydrationWarning` and the blocking script.

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/context/theme-provider.tsx` | Added comprehensive JSDoc documenting SSR/hydration strategy |
| `frontend/src/app/layout.tsx` | Added blocking inline `<script>` in `<head>`; updated comments |

## Testing

- TypeScript: `tsc --noEmit` — no new errors
- Tests: 184 tests passing (20/21 suites), 1 pre-existing failure unrelated
- Lint: no new warnings/errors

## Manual Verification

To reproduce the original issue:
1. Set theme to `light` in settings
2. Hard-refresh the page
3. **Before fix:** Observe a flash of dark theme before it switches to light
4. **After fix:** The page renders in light theme from the first frame
