### PR TITLE
docs(security): add cross-references between security policy documents

### DIFF
--- a/.github/SECURITY_SETUP_CHECKLIST.md
+++ b/.github/SECURITY_SETUP_CHECKLIST.md
@@ -1,6 +1,6 @@
 # GitHub Security Setup Checklist
 
-This checklist helps ensure that GitHub's security features are properly configured for the FlowFi repository.
+This checklist helps repository administrators ensure that GitHub's security features are properly configured for the FlowFi repository. For the canonical security policy (reporting guidelines, supported versions, response timelines), see [SECURITY.md](../SECURITY.md). For the implementation status and next steps, see [SECURITY_IMPLEMENTATION_SUMMARY.md](../SECURITY_IMPLEMENTATION_SUMMARY.md).
 
 ## Repository Security Settings
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Security Policy
 
+This is the canonical security policy for FlowFi. It defines how vulnerabilities are reported, which versions are supported, and the responsible disclosure process. For contributors and administrators setting up repository security features, see [SECURITY_IMPLEMENTATION_SUMMARY.md](SECURITY_IMPLEMENTATION_SUMMARY.md). For the GitHub setup checklist, see [.github/SECURITY_SETUP_CHECKLIST.md](.github/SECURITY_SETUP_CHECKLIST.md).
+
 ## Supported Versions
 
 We actively support the following versions of FlowFi with security updates:

--- a/SECURITY_IMPLEMENTATION_SUMMARY.md
+++ b/SECURITY_IMPLEMENTATION_SUMMARY.md
@@ -1,6 +1,6 @@
 # Security Policy Implementation Summary
 
-This document summarizes the security policy implementation for FlowFi and provides next steps for repository administrators.
+This document is a **maintenance and onboarding guide** for repository administrators and contributors. It tracks which security measures have been implemented and what steps remain. It is not a replacement for the security policy itself. For the canonical security policy (reporting guidelines, supported versions, response timelines), see [SECURITY.md](SECURITY.md). For the GitHub security setup checklist, see [.github/SECURITY_SETUP_CHECKLIST.md](.github/SECURITY_SETUP_CHECKLIST.md).
 
 ## ✅ Completed Tasks
 


### PR DESCRIPTION
Add explicit cross-links between SECURITY.md, SECURITY_IMPLEMENTATION_SUMMARY.md, and .github/SECURITY_SETUP_CHECKLIST.md.

- Clarify each file's distinct purpose in its opening paragraph
- Add explicit cross-links so readers can find all three security docs

Closes #1092