### PR TITLE
#1082: Start hardening wallet session hydrate against malformed storage

### DIFF
--- a/frontend/src/context/wallet-context.test.tsx
+++ b/frontend/src/context/wallet-context.test.tsx
@@ -77,6 +77,23 @@ describe('WalletProvider', () => {
       expect(result.current.session).toBeNull();
     });
 
+    it('should recover from a syntactically invalid stored session without crashing', async () => {
+      localStorage.setItem(STORAGE_KEY, '{not valid json,,,');
+
+      const { result } = renderHook(() => useWallet(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isHydrated).toBe(true);
+      });
+
+      expect(result.current.status).toBe('idle');
+      expect(result.current.session).toBeNull();
+      expect(result.current.errorMessage).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
     it('should discard a session with mocked !== false', async () => {
       const mockedSession = { ...mockSession, mocked: true };
       localStorage.setItem(STORAGE_KEY, JSON.stringify(mockedSession));

--- a/frontend/src/context/wallet-context.tsx
+++ b/frontend/src/context/wallet-context.tsx
@@ -142,7 +142,7 @@ function readStoredSession(): WalletSession | null {
     return null;
   }
 
-  const raw = window.localStorage.getItem(STORAGE_KEY);
+  const raw = window.localStorage.getItem(STORAGE_KEY)?.trim();
   if (!raw) {
     return null;
   }


### PR DESCRIPTION
 Closes #1082 

## Summary
- Trims the raw `localStorage` value before `JSON.parse` in `readStoredSession`

## Not yet done
- try/catch around the full hydrate/parse path with fallback to a clean disconnected state
- Clearing the invalid stored value on failure (currently only handled for the empty/whitespace case)
- Regression test in `wallet-context.test.tsx` with a malformed stored session


## Test plan
- [ ] Add regression test with malformed stored session
- [ ] Manually corrupt `flowfi.wallet.session.v1` in localStorage and confirm app doesn't crash