### PR TITLE
fix(frontend): document SSR/hydration guard in theme provider (#1083)

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -60,7 +60,18 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning> {/* TODO: revisit if i18n is introduced */}
+    /*
+      `suppressHydrationWarning` is the companion to next-themes' built-in
+      blocking pre-paint script (rendered by <ThemeProvider> below). The
+      server renders <html> without a theme class; that script then reads the
+      persisted theme from localStorage and adds/removes the theme class
+      (`light`/`dark`) on <html> before the first paint, so the client DOM
+      class list can legitimately differ from what the server rendered. This
+      prop tells React to skip the hydration-difference check for this
+      element because the divergence is intentional and resolved before paint.
+      See `theme-provider.tsx` for the full strategy.
+    */
+    <html lang="en" suppressHydrationWarning>
       <head />
       <body className={`${sora.variable} ${mono.variable} antialiased`}>
         <ThemeProvider

--- a/frontend/src/context/theme-provider.tsx
+++ b/frontend/src/context/theme-provider.tsx
@@ -3,6 +3,62 @@
 import * as React from "react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 
+/**
+ * Thin wrapper around `next-themes`' `ThemeProvider` that centralises the
+ * theme configuration for the FlowFi frontend.
+ *
+ * ## SSR / hydration strategy (no flash-of-wrong-theme, no hydration warnings)
+ *
+ * Theme selection is inherently client-side: it depends on `localStorage` and,
+ * for the `system` theme, on `matchMedia`. The server cannot know the user's
+ * preference, so it renders `<html>` **without a theme class**; the correct
+ * class is applied only on the client. Without the guard described below, two
+ * problems would follow:
+ *
+ * 1. **Flash of wrong theme (FOUC)** — the browser would paint with the
+ *    default styles first (no class means Tailwind's `dark:` variants are
+ *    off, i.e. light mode), then swap to the persisted theme once the client
+ *    applies it after hydration.
+ * 2. **Hydration mismatch warning** — React compares the server-rendered
+ *    `<html>` class list with the client DOM and warns if they differ.
+ *
+ * Both are prevented today, without any custom script:
+ *
+ * - `next-themes@0.4.x` renders its **own blocking inline `<script>`** (the
+ *   library's core feature — see the installed package source,
+ *   `node_modules/next-themes/dist/index.js`) that runs **before the browser
+ *   paints**. It reads the value stored under `storageKey` ("flowfi-theme"),
+ *   falls back to `defaultTheme` ("dark"), resolves `"system"` via
+ *   `matchMedia("(prefers-color-scheme: dark)")`, and adds/removes the theme
+ *   class (`light`/`dark`) on `document.documentElement`. Because the class is
+ *   already correct before the first frame is drawn, there is no flash of the
+ *   wrong theme.
+ *
+ * - The `suppressHydrationWarning` prop on `<html>` in `app/layout.tsx` tells
+ *   React to skip the hydration diff check for that element, since the
+ *   class-list divergence is intentional: the pre-paint script mutates the
+ *   class after the server rendered the markup.
+ *
+ * We deliberately do **not** hand-roll a second inline script. The library's
+ * built-in script already performs this exact sequence, and a duplicate would
+ * race it — two sources of truth mutating the same class list is redundant and
+ * brittle if the storage key or theme values ever change. Keeping the strategy
+ * in one place (next-themes) is the safest option.
+ *
+ * ## Configuration
+ *
+ * - `attribute="class"` — toggles the `dark` class on `<html>`, which Tailwind
+ *   uses for its `dark:` variant.
+ * - `defaultTheme="dark"` — the theme the pre-paint script applies for users
+ *   without a stored preference (and the initial value `useTheme()` reports
+ *   before hydration).
+ * - `enableSystem={true}` — allows a `"system"` theme that follows the OS
+ *   `prefers-color-scheme` media query.
+ * - `storageKey="flowfi-theme"` — namespaced localStorage key used by
+ *   `next-themes`' pre-paint script and by `setTheme()` persistence.
+ * - `disableTransitionOnChange` — prevents a brief CSS transition flash when
+ *   the theme class changes.
+ */
 export function ThemeProvider({
   children,
   ...props


### PR DESCRIPTION
## Description

Closes #1083

This PR resolves the open SSR/hydration concern for the theme provider by **documenting the existing guard strategy in code comments** rather than adding a redundant hand-rolled inline script.

**Context:** A previous attempt (PR #1158) added a custom blocking inline `<script>` to `layout.tsx`. A maintainer closed it with the guidance that `main` already ships both halves of the protection:

1. `suppressHydrationWarning` on `<html>` in `frontend/src/app/layout.tsx` — tells React to skip the hydration diff check for the class attribute, since the pre-paint script intentionally mutates it.
2. `next-themes@0.4.6`'s **built-in** blocking pre-paint script (the library's core feature) — it reads `localStorage["flowfi-theme"]`, resolves `"system"` via `matchMedia("(prefers-color-scheme: dark)")`, and adds/removes the `dark` class on `document.documentElement` **before the first paint**.

A second hand-rolled script would race the built-in one, so this PR deliberately does **not** add one. Instead it documents the strategy so the intent is preserved for future contributors (acceptance criterion: *"Document the approach in a code comment"*).

## Type of Change

- [x] 📚 Documentation update (comment-only change that resolves a bug-flagged issue)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update

## Related Issues

Closes #1083

## Changes Made

- **`frontend/src/context/theme-provider.tsx`** — Added a JSDoc block documenting the full SSR/hydration strategy:
  - How `next-themes`' built-in pre-paint script prevents flash-of-wrong-theme (FOUC).
  - How `suppressHydrationWarning` on `<html>` prevents the hydration mismatch warning.
  - Why we do **not** hand-roll a second inline script (it would race the library's own script and create two sources of truth).
  - What each `ThemeProvider` prop does (`attribute`, `defaultTheme`, `enableSystem`, `storageKey`, `disableTransitionOnChange`).
- **`frontend/src/app/layout.tsx`** — Replaced the stale `TODO` comment with an explanation of why `suppressHydrationWarning` is on `<html>` and how it pairs with the next-themes pre-paint script rendered by `<ThemeProvider>`.

No functional change — the current behavior already satisfies acceptance criteria 1–2 (see Testing for evidence).

## Testing

- `npm run lint --workspace=frontend` — **0 errors** (5 pre-existing warnings in unrelated files)
- `npm run build --workspace=frontend` (Next.js 16.2.9, Turbopack) — **succeeds**
- `npm test --workspace=frontend` — **206 tests passed** (24 files)
- Inspected the prerendered SSR output (`.next/server/app/index.html`) to confirm current behavior:
  - `suppressHydrationWarning:true` is serialized on the `<html>` element in the React tree (honored at hydration).
  - The next-themes **pre-paint script is present in the HTML**: `...("class","flowfi-theme","dark",null,["light","dark",...])` — the library's inline script reads `localStorage["flowfi-theme"]` (default `"dark"`) and applies the class before paint.
  - ThemeProvider props are serialized consistently (`attribute="class"`, `defaultTheme="dark"`, `enableSystem=true`, `storageKey="flowfi-theme"`, `disableTransitionOnChange`).

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed (see Test Steps)

### Test Steps

Manual repro for reviewers:

1. `cd frontend && npm run dev`
2. In DevTools, run `localStorage.setItem('flowfi-theme', 'light')` and hard-reload — there is **no** dark→light flash on load (theme is correct before first paint).
3. With DevTools console open, reload — **no `Hydration mismatch` warnings**.
4. Toggle the theme via the navbar control — the preference persists across reloads with no flash.

## Breaking Changes

None — comment-only change.

**Migration Guide:** N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Updated Postman/Hoppscotch API collections if routes changed (N/A)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — comment-only change; behavior verified via build output + existing suite)
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked for breaking changes and documented them if applicable

## Additional Notes

- Related closed PR: **#1158** (superseded — its hand-rolled inline script was rejected because it would race `next-themes`' built-in script; this PR follows that guidance).
- The `pre-commit` hook (lint-staged → `npm run lint --workspace=frontend`) passed on commit.
