### PR TITLE
docs(CONTRIBUTING.md): add all-contributors badge usage documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -472,6 +472,47 @@ Be constructive.
 
 ---
 
+
+
+---
+
+# 🤝 Contributor Badges
+
+This project uses the [all-contributors](https://github.com/all-contributors/all-contributors) specification to recognize contributors.
+
+## Triggering the Bot
+
+After your pull request is merged or closed, comment on the merged PR or issue:
+
+```
+@all-contributors please add @<your-username> for code
+```
+
+The bot will add your profile to the Contributors table in the root `README.md`.
+
+## Adding Sub-Package READMEs
+
+Currently, only the root `README.md` has a Contributors section. If you add a Contributors section to a sub-package README (e.g., `backend/README.md`, `frontend/README.md`, `contracts/README.md`), update `.all-contributorsrc` in the repo root to include the additional path:
+
+```json
+"files": [
+  "README.md",
+  "backend/README.md"
+]
+```
+
+## Available Contribution Types
+
+- `code` — Code contributions
+- `doc` — Documentation
+- `design` — Design
+- `bug` — Bug reports
+- `review` — Pull Request reviews
+- `test` — Testing
+- `infra` — Infrastructure / DevOps
+- `ideas` — Ideas & planning
+
+
 # Final Notes
 
 - Contributions of all sizes are welcome


### PR DESCRIPTION
## Summary

### What changed

- Added a **Contributor Badges** section to `CONTRIBUTING.md` documenting how to use the `@all-contributors` bot
- Documents the trigger command, available contribution types, and how to add sub-package READMEs to `.all-contributorsrc` in the future

### Why

`.all-contributorsrc` only tracks `README.md` for contributor badges. This change documents the process so contributors know how to trigger the bot and how to extend the tracking to sub-package READMEs if needed.

### Verification

- `.all-contributorsrc` `files: ["README.md"]` is already correct — only root README.md has a Contributors section
- `backend/README.md`, `frontend/README.md`, `contracts/README.md` were checked and none have a Contributors section

Closes #1076