### PR TITLE
Fix auth on SSE stats endpoint

### DIFF
--- a/backend/src/routes/v1/events.routes.ts
+++ b/backend/src/routes/v1/events.routes.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import { subscribe } from '../../controllers/sse.controller.js';
 import { sseService } from '../../services/sse.service.js';
-import { requireAuth } from '../../middleware/auth.js';
+import { requireAdmin, requireAuth } from '../../middleware/auth.js';
 import type { AuthenticatedRequest } from '../../types/auth.types.js';
 import { prisma } from '../../lib/prisma.js';
 import logger from '../../logger.js';
@@ -247,7 +247,7 @@ router.get('/subscribe', requireAuth, subscribe);
  *                   type: string
  *                   format: date-time
  */
-router.get('/stats', (req: Request, res: Response) => {
+router.get('/stats', requireAdmin, (req: Request, res: Response) => {
   res.json({
     activeConnections: sseService.getClientCount(),
     activeIps: sseService.getActiveIpCount(),

--- a/backend/tests/integration/admin-metrics.test.ts
+++ b/backend/tests/integration/admin-metrics.test.ts
@@ -149,6 +149,35 @@ function setupCounts({
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
+describe('GET /v1/events/stats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ADMIN_PUBLIC_KEY = ADMIN_PUBLIC_KEY;
+  });
+
+  it('enforces requireAdmin (401 without token, 403 with non-admin token)', async () => {
+    const noTokenRes = await request(app).get('/v1/events/stats');
+    expect(noTokenRes.status).toBe(401);
+
+    const nonAdminRes = await request(app)
+      .get('/v1/events/stats')
+      .set('Authorization', `Bearer ${createToken(NON_ADMIN_PUBLIC_KEY)}`);
+    expect(nonAdminRes.status).toBe(403);
+
+    const adminRes = await request(app)
+      .get('/v1/events/stats')
+      .set('Authorization', `Bearer ${createToken()}`);
+    expect(adminRes.status).toBe(200);
+    expect(adminRes.body).toMatchObject({
+      activeConnections: expect.any(Number),
+      activeIps: expect.any(Number),
+      perIpPeakConnections: expect.any(Number),
+      maxConnections: expect.any(Number),
+      timestamp: expect.any(String),
+    });
+  });
+});
+
 describe('GET /v1/admin/metrics', () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary

Fixes the operational SSE metrics disclosure in the API by requiring admin authentication on the public stats endpoint.

### What changed
- Added the `requireAdmin` middleware to `GET /v1/events/stats` in [backend/src/routes/v1/events.routes.ts](backend/src/routes/v1/events.routes.ts).
- Added a regression test covering the required 401/403 behavior and successful admin access in [backend/tests/integration/admin-metrics.test.ts](backend/tests/integration/admin-metrics.test.ts).

### Why
The endpoint previously exposed live SSE connection metrics without any authorization, including active connection totals and per-IP peak usage. This exposed operational telemetry useful for reconnaissance while bypassing the admin-only protections already used elsewhere in the API.

### Verification
- Ran: `cd /workspaces/flowfi/backend && npx vitest run tests/integration/admin-metrics.test.ts --coverage.enabled=false --reporter=default --silent`
- Result: 1 test file passed, 18 tests passed, exit code 0.

Closes #1237
