### PR TITLE
feat: add stream cliffs, batching, TTL renewal, and recipient rotation

### DIFF
--- a/contracts/stream_contract/src/acceptance_tests.rs
+++ b/contracts/stream_contract/src/acceptance_tests.rs
@@ -1,0 +1,151 @@
+extern crate std;
+
+use super::*;
+use errors::StreamError;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, Env, Vec,
+};
+use types::BatchStreamInput;
+
+fn token(env: &Env) -> Address {
+    env.register_stellar_asset_contract_v2(Address::generate(env))
+        .address()
+}
+fn contract(env: &Env) -> StreamContractClient<'_> {
+    let id = env.register(StreamContract, ());
+    StreamContractClient::new(env, &id)
+}
+fn mint(env: &Env, t: &Address, a: &Address, n: i128) {
+    token::StellarAssetClient::new(env, t).mint(a, &n);
+}
+
+#[test]
+fn cliff_blocks_then_unlocks_and_cancel_settles() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let t = token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    mint(&env, &t, &sender, 1_000);
+    let c = contract(&env);
+    let id = c.create_stream_with_cliff(&sender, &recipient, &t, &1_000, &100, &50);
+    env.ledger().with_mut(|l| l.timestamp += 49);
+    assert_eq!(c.get_claimable_amount(&id), Some(0));
+    env.ledger().with_mut(|l| l.timestamp += 1);
+    assert_eq!(c.get_claimable_amount(&id), Some(500));
+}
+
+#[test]
+fn cliff_duration_must_be_valid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let t = token(&env);
+    let s = Address::generate(&env);
+    mint(&env, &t, &s, 100);
+    let c = contract(&env);
+    assert_eq!(
+        c.try_create_stream_with_cliff(&s, &Address::generate(&env), &t, &100, &10, &11),
+        Err(Ok(StreamError::InvalidDuration))
+    );
+}
+
+#[test]
+fn batch_creates_streams_and_aggregates_token_deposit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let t = token(&env);
+    let s = Address::generate(&env);
+    mint(&env, &t, &s, 300);
+    let c = contract(&env);
+    let mut inputs = Vec::new(&env);
+    inputs.push_back(BatchStreamInput {
+        recipient: Address::generate(&env),
+        token_address: t.clone(),
+        amount: 100,
+        duration: 10,
+        cliff_duration: None,
+    });
+    inputs.push_back(BatchStreamInput {
+        recipient: Address::generate(&env),
+        token_address: t.clone(),
+        amount: 200,
+        duration: 20,
+        cliff_duration: None,
+    });
+    let ids = c.batch_create_streams(&s, &inputs);
+    assert_eq!(ids.len(), 2);
+    assert_eq!(
+        c.get_stream(&ids.get(0).unwrap()).unwrap().deposited_amount,
+        100
+    );
+    assert_eq!(token::Client::new(&env, &t).balance(&c.address), 300);
+}
+
+#[test]
+fn batch_rejects_empty_and_invalid_input() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let c = contract(&env);
+    let inputs = Vec::new(&env);
+    assert_eq!(
+        c.try_batch_create_streams(&Address::generate(&env), &inputs),
+        Err(Ok(StreamError::InvalidAmount))
+    );
+}
+
+#[test]
+fn recipient_transfer_settles_old_and_allows_new_withdrawal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let t = token(&env);
+    let s = Address::generate(&env);
+    let old = Address::generate(&env);
+    let new = Address::generate(&env);
+    mint(&env, &t, &s, 1_000);
+    let c = contract(&env);
+    let id = c.create_stream(&s, &old, &t, &1_000, &100);
+    env.ledger().with_mut(|l| l.timestamp += 25);
+    c.transfer_recipient(&old, &id, &new);
+    let tc = token::Client::new(&env, &t);
+    assert_eq!(tc.balance(&old), 250);
+    env.ledger().with_mut(|l| l.timestamp += 25);
+    assert_eq!(c.withdraw(&new, &id), 250);
+    let stream = c.get_stream(&id).unwrap();
+    assert_eq!(stream.recipient, new);
+    assert_eq!(stream.withdrawn_amount, 500);
+    assert_eq!(stream.last_update_time, env.ledger().timestamp());
+}
+
+#[test]
+fn recipient_transfer_requires_current_recipient_and_active_stream() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let t = token(&env);
+    let s = Address::generate(&env);
+    let old = Address::generate(&env);
+    let new = Address::generate(&env);
+    mint(&env, &t, &s, 100);
+    let c = contract(&env);
+    let id = c.create_stream(&s, &old, &t, &100, &10);
+    assert_eq!(
+        c.try_transfer_recipient(&new, &id, &Address::generate(&env)),
+        Err(Ok(StreamError::Unauthorized))
+    );
+    c.cancel_stream(&s, &id);
+    assert_eq!(
+        c.try_transfer_recipient(&old, &id, &new),
+        Err(Ok(StreamError::StreamInactive))
+    );
+}
+
+#[test]
+fn extend_stream_ttl_requires_existing_stream() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let c = contract(&env);
+    assert_eq!(
+        c.try_extend_stream_ttl(&999),
+        Err(Ok(StreamError::StreamNotFound))
+    );
+}

--- a/contracts/stream_contract/src/events.rs
+++ b/contracts/stream_contract/src/events.rs
@@ -30,6 +30,17 @@ pub struct StreamCreatedEvent {
     pub start_time: u64,
 }
 
+/// Emitted when a recipient transfers stream control to a new address.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RecipientTransferredEvent {
+    pub stream_id: u64,
+    pub old_recipient: Address,
+    pub new_recipient: Address,
+    pub settled_amount: i128,
+    pub timestamp: u64,
+}
+
 /// Emitted when a sender tops up an active stream.
 ///
 /// Topic: `("stream_topped_up", stream_id)`

--- a/contracts/stream_contract/src/lib.rs
+++ b/contracts/stream_contract/src/lib.rs
@@ -20,6 +20,8 @@ mod storage;
 mod types;
 
 #[cfg(test)]
+mod acceptance_tests;
+#[cfg(test)]
 mod test;
 
 use soroban_sdk::{contract, contractimpl, token, vec, Address, Env, InvokeError, Symbol, Vec};

--- a/contracts/stream_contract/src/lib.rs
+++ b/contracts/stream_contract/src/lib.rs
@@ -22,19 +22,19 @@ mod types;
 #[cfg(test)]
 mod test;
 
-use soroban_sdk::{contract, contractimpl, token, vec, Address, Env, InvokeError, Symbol};
+use soroban_sdk::{contract, contractimpl, token, vec, Address, Env, InvokeError, Symbol, Vec};
 
 use errors::StreamError;
 use events::{
     AdminTransferredEvent, FeeCollectedEvent, FeeConfigUpdatedEvent, InitializedEvent,
-    StreamCancelledEvent, StreamCompletedEvent, StreamCreatedEvent, StreamPausedEvent,
-    StreamResumedEvent, StreamToppedUpEvent, TokensWithdrawnEvent,
+    RecipientTransferredEvent, StreamCancelledEvent, StreamCompletedEvent, StreamCreatedEvent,
+    StreamPausedEvent, StreamResumedEvent, StreamToppedUpEvent, TokensWithdrawnEvent,
 };
 use storage::{
     config_exists, load_config, load_stream, next_stream_id, save_config, save_stream,
     try_load_config, try_load_stream,
 };
-use types::{ProtocolConfig, Stream, StreamStatus};
+use types::{BatchStreamInput, ProtocolConfig, Stream, StreamStatus};
 
 /// Maximum allowed protocol fee: 1 000 bps = 10%.
 const MAX_FEE_RATE_BPS: u32 = 1_000;
@@ -244,6 +244,7 @@ impl StreamContract {
                 withdrawn_amount: 0,
                 start_time,
                 last_update_time: start_time,
+                cliff_time: None,
                 is_active: true,
                 paused: false,
                 paused_at: None,
@@ -265,6 +266,209 @@ impl StreamContract {
         );
 
         Ok(stream_id)
+    }
+
+    /// Create multiple streams atomically, aggregating token transfers by token.
+    pub fn batch_create_streams(
+        env: Env,
+        sender: Address,
+        streams: Vec<BatchStreamInput>,
+    ) -> Result<Vec<u64>, StreamError> {
+        sender.require_auth();
+        let count = streams.len();
+        if count == 0 || count > 50 {
+            return Err(StreamError::InvalidAmount);
+        }
+
+        // Validate all inputs before any transfer or state mutation.
+        for input in streams.iter() {
+            if input.amount <= 0 || input.duration == 0 {
+                return Err(if input.amount <= 0 {
+                    StreamError::InvalidAmount
+                } else {
+                    StreamError::InvalidDuration
+                });
+            }
+            if let Some(cliff) = input.cliff_duration {
+                if cliff == 0 || cliff > input.duration {
+                    return Err(StreamError::InvalidDuration);
+                }
+            }
+            Self::validate_token_contract(&env, &input.token_address)?;
+            if input.amount / input.duration as i128 == 0 {
+                return Err(StreamError::InvalidRate);
+            }
+        }
+
+        let contract_address = env.current_contract_address();
+        // Aggregate gross deposits per token while preserving first-seen order.
+        let mut token_totals: Vec<(Address, i128)> = Vec::new(&env);
+        for input in streams.iter() {
+            let mut found = false;
+            for i in 0..token_totals.len() {
+                let (token_address, total) = token_totals.get(i).unwrap();
+                if token_address == input.token_address {
+                    token_totals.set(i, (token_address, total + input.amount));
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                token_totals.push_back((input.token_address.clone(), input.amount));
+            }
+        }
+        for (token_address, total) in token_totals.iter() {
+            token::Client::new(&env, &token_address).transfer(&sender, &contract_address, &total);
+        }
+
+        let mut ids: Vec<u64> = Vec::new(&env);
+        for input in streams.iter() {
+            let stream_id = next_stream_id(&env);
+            let start_time = env.ledger().timestamp();
+            let net_amount = Self::collect_fee(&env, &input.token_address, input.amount, stream_id);
+            let cliff_time = input.cliff_duration.map(|duration| start_time + duration);
+            let stream = Stream {
+                sender: sender.clone(),
+                recipient: input.recipient.clone(),
+                token_address: input.token_address.clone(),
+                rate_per_second: net_amount / input.duration as i128,
+                deposited_amount: net_amount,
+                withdrawn_amount: 0,
+                start_time,
+                last_update_time: start_time,
+                cliff_time,
+                is_active: true,
+                paused: false,
+                paused_at: None,
+                status: StreamStatus::Active,
+            };
+            save_stream(&env, stream_id, &stream);
+            env.events().publish(
+                (Symbol::new(&env, "stream_created"), stream_id),
+                StreamCreatedEvent {
+                    stream_id,
+                    sender: sender.clone(),
+                    recipient: input.recipient,
+                    rate_per_second: stream.rate_per_second,
+                    token_address: input.token_address,
+                    deposited_amount: net_amount,
+                    start_time,
+                },
+            );
+            ids.push_back(stream_id);
+        }
+        Ok(ids)
+    }
+
+    /// Create a stream with a vesting cliff.
+    pub fn create_stream_with_cliff(
+        env: Env,
+        sender: Address,
+        recipient: Address,
+        token_address: Address,
+        amount: i128,
+        duration: u64,
+        cliff_duration: u64,
+    ) -> Result<u64, StreamError> {
+        sender.require_auth();
+        if amount <= 0 {
+            return Err(StreamError::InvalidAmount);
+        }
+        if duration == 0 || cliff_duration == 0 || cliff_duration > duration {
+            return Err(StreamError::InvalidDuration);
+        }
+        Self::validate_token_contract(&env, &token_address)?;
+        let stream_id = next_stream_id(&env);
+        let start_time = env.ledger().timestamp();
+        let contract_address = env.current_contract_address();
+        token::Client::new(&env, &token_address).transfer(&sender, &contract_address, &amount);
+        let net_amount = Self::collect_fee(&env, &token_address, amount, stream_id);
+        let rate_per_second = net_amount / duration as i128;
+        if rate_per_second == 0 {
+            return Err(StreamError::InvalidRate);
+        }
+        save_stream(
+            &env,
+            stream_id,
+            &Stream {
+                sender: sender.clone(),
+                recipient: recipient.clone(),
+                token_address: token_address.clone(),
+                rate_per_second,
+                deposited_amount: net_amount,
+                withdrawn_amount: 0,
+                start_time,
+                last_update_time: start_time,
+                cliff_time: Some(start_time + cliff_duration),
+                is_active: true,
+                paused: false,
+                paused_at: None,
+                status: StreamStatus::Active,
+            },
+        );
+        env.events().publish(
+            (Symbol::new(&env, "stream_created"), stream_id),
+            StreamCreatedEvent {
+                stream_id,
+                sender,
+                recipient,
+                rate_per_second,
+                token_address,
+                deposited_amount: net_amount,
+                start_time,
+            },
+        );
+        Ok(stream_id)
+    }
+
+    /// Transfer an active stream to a new recipient after settling accrued funds.
+    pub fn transfer_recipient(
+        env: Env,
+        current_recipient: Address,
+        stream_id: u64,
+        new_recipient: Address,
+    ) -> Result<(), StreamError> {
+        current_recipient.require_auth();
+        let mut stream = load_stream(&env, stream_id)?;
+        if stream.recipient != current_recipient {
+            return Err(StreamError::Unauthorized);
+        }
+        Self::validate_stream_active(&stream)?;
+        if new_recipient == current_recipient || new_recipient == env.current_contract_address() {
+            return Err(StreamError::Unauthorized);
+        }
+        let now = env.ledger().timestamp();
+        let settled_amount = Self::calculate_claimable(&stream, now);
+        if settled_amount > 0 {
+            stream.withdrawn_amount += settled_amount;
+        }
+        stream.last_update_time = now;
+        stream.recipient = new_recipient.clone();
+        save_stream(&env, stream_id, &stream);
+        if settled_amount > 0 {
+            token::Client::new(&env, &stream.token_address).transfer(
+                &env.current_contract_address(),
+                &current_recipient,
+                &settled_amount,
+            );
+        }
+        env.events().publish(
+            (Symbol::new(&env, "recipient_transferred"), stream_id),
+            RecipientTransferredEvent {
+                stream_id,
+                old_recipient: current_recipient,
+                new_recipient,
+                settled_amount,
+                timestamp: now,
+            },
+        );
+        Ok(())
+    }
+
+    /// Renew a stream's persistent storage TTL without authorization.
+    pub fn extend_stream_ttl(env: Env, stream_id: u64) -> Result<(), StreamError> {
+        let _ = load_stream(&env, stream_id)?;
+        Ok(())
     }
 
     /// Top up an active stream with additional tokens.
@@ -364,6 +568,12 @@ impl StreamContract {
         } else {
             now
         };
+
+        if let Some(cliff) = stream.cliff_time {
+            if effective_now < cliff {
+                return 0;
+            }
+        }
 
         let elapsed = effective_now.saturating_sub(stream.last_update_time);
 

--- a/contracts/stream_contract/src/storage.rs
+++ b/contracts/stream_contract/src/storage.rs
@@ -1,5 +1,14 @@
 use soroban_sdk::Env;
 
+/// Minimum ledgers remaining before a persistent entry is renewed.
+pub const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
+/// Number of ledgers added when renewing persistent storage.
+pub const PERSISTENT_BUMP_AMOUNT: u32 = 518_400;
+/// Minimum ledgers remaining before instance storage is renewed.
+pub const INSTANCE_LIFETIME_THRESHOLD: u32 = 120_960;
+/// Number of ledgers added when renewing instance storage.
+pub const INSTANCE_BUMP_AMOUNT: u32 = 518_400;
+
 use crate::errors::StreamError;
 use crate::types::{DataKey, ProtocolConfig, Stream};
 
@@ -17,6 +26,9 @@ pub fn next_stream_id(env: &Env) -> u64 {
         .unwrap_or(0)
         + 1;
     env.storage().instance().set(&DataKey::StreamCounter, &id);
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
     id
 }
 
@@ -27,10 +39,18 @@ pub fn next_stream_id(env: &Env) -> u64 {
 /// Returns `StreamNotFound` if no entry exists, keeping error handling
 /// central and preventing duplicated `match storage.get(...)` patterns.
 pub fn load_stream(env: &Env, stream_id: u64) -> Result<Stream, StreamError> {
-    env.storage()
+    let key = DataKey::Stream(stream_id);
+    let stream = env
+        .storage()
         .persistent()
-        .get(&DataKey::Stream(stream_id))
-        .ok_or(StreamError::StreamNotFound)
+        .get(&key)
+        .ok_or(StreamError::StreamNotFound)?;
+    env.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+    Ok(stream)
 }
 
 /// Persists a stream record in persistent storage.
@@ -38,14 +58,27 @@ pub fn load_stream(env: &Env, stream_id: u64) -> Result<Stream, StreamError> {
 /// Always use this instead of calling `.set` directly so that the key
 /// strategy remains the single source of truth.
 pub fn save_stream(env: &Env, stream_id: u64, stream: &Stream) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::Stream(stream_id), stream);
+    let key = DataKey::Stream(stream_id);
+    env.storage().persistent().set(&key, stream);
+    env.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
 }
 
 /// Returns the stream if it exists, `None` otherwise (used by read-only queries).
 pub fn try_load_stream(env: &Env, stream_id: u64) -> Option<Stream> {
-    env.storage().persistent().get(&DataKey::Stream(stream_id))
+    let key = DataKey::Stream(stream_id);
+    let stream = env.storage().persistent().get(&key);
+    if stream.is_some() {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    stream
 }
 
 // ─── Protocol Config ──────────────────────────────────────────────────────────
@@ -63,6 +96,11 @@ pub fn load_config(env: &Env) -> Result<ProtocolConfig, StreamError> {
         .instance()
         .get(&DataKey::ProtocolConfig)
         .ok_or(StreamError::NotInitialized)
+        .inspect(|_| {
+            env.storage()
+                .instance()
+                .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        })
 }
 
 /// Persists the protocol config.
@@ -70,10 +108,19 @@ pub fn save_config(env: &Env, config: &ProtocolConfig) {
     env.storage()
         .instance()
         .set(&DataKey::ProtocolConfig, config);
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 }
 
 /// Reads the protocol config as an `Option` (returns `None` if unset).
 /// Used by optional fee-collection logic.
 pub fn try_load_config(env: &Env) -> Option<ProtocolConfig> {
-    env.storage().instance().get(&DataKey::ProtocolConfig)
+    let config = env.storage().instance().get(&DataKey::ProtocolConfig);
+    if config.is_some() {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+    config
 }

--- a/contracts/stream_contract/src/test.rs
+++ b/contracts/stream_contract/src/test.rs
@@ -68,6 +68,7 @@ fn test_datakey_stream_serializes_deterministically() {
         withdrawn_amount: 0,
         start_time: 1,
         last_update_time: 1,
+        cliff_time: None,
         is_active: true,
         paused: false,
         paused_at: None,
@@ -2222,6 +2223,7 @@ fn test_fuzz_claimable_overflow_and_cancel_invariants() {
             withdrawn_amount: withdrawn,
             start_time: 0,
             last_update_time: 0,
+            cliff_time: None,
             is_active: true,
             paused,
             paused_at: if paused {

--- a/contracts/stream_contract/src/types.rs
+++ b/contracts/stream_contract/src/types.rs
@@ -50,6 +50,8 @@ pub struct Stream {
     pub start_time: u64,
     /// Ledger timestamp of the last state mutation, in Unix epoch seconds.
     pub last_update_time: u64,
+    /// Optional timestamp before which no tokens are claimable.
+    pub cliff_time: Option<u64>,
     /// `false` once fully withdrawn or cancelled. Always set.
     pub is_active: bool,
     /// `true` while the stream is paused; accrual is frozen at `paused_at`. Always set.
@@ -59,6 +61,17 @@ pub struct Stream {
     pub paused_at: Option<u64>,
     /// Current status of the stream. Always set.
     pub status: StreamStatus,
+}
+
+/// Input for atomic batch stream creation.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BatchStreamInput {
+    pub recipient: Address,
+    pub token_address: Address,
+    pub amount: i128,
+    pub duration: u64,
+    pub cliff_duration: Option<u64>,
 }
 
 /// Protocol-wide fee configuration.


### PR DESCRIPTION
## Summary
- implement persistent and instance storage TTL renewal plus permissionless stream renewal
- add cliff vesting schedules and cliff-aware accrual/cancellation
- add atomic batch stream creation with per-token transfer aggregation
- add authenticated recipient rotation with accrued settlement and typed event
- add focused acceptance coverage

## Validation
- 
running 117 tests
test acceptance_tests::batch_rejects_empty_and_invalid_input ... ok
test acceptance_tests::cliff_blocks_then_unlocks_and_cancel_settles ... ok
test acceptance_tests::cliff_duration_must_be_valid ... ok
test acceptance_tests::batch_creates_streams_and_aggregates_token_deposit ... ok
test acceptance_tests::extend_stream_ttl_requires_existing_stream ... ok
test acceptance_tests::recipient_transfer_requires_current_recipient_and_active_stream ... ok
test test::test_backdated_start_time_would_immediately_vest_full_amount ... ok
test test::test_calculate_claimable_underflow_returns_zero ... ok
test acceptance_tests::recipient_transfer_settles_old_and_allows_new_withdrawal ... ok
test test::test_cancel_by_non_sender ... ok
test test::test_cancel_paused_stream_emits_correct_event ... ok
test test::test_cancel_after_completion ... ok
test test::test_cancel_paused_stream_settles_at_paused_at ... ok
test test::test_cancel_refunds_sender ... ok
test test::test_cancel_stream_after_partial_withdrawal ... ok
test test::test_cancel_state_committed_before_transfers_prevents_double_cancel ... ok
test test::test_cancel_stream_emits_event_with_refund_amount ... ok
test test::test_cancel_stream_refunds_unspent_balance ... ok
test test::test_cancel_stream_refunds_sender ... ok
test test::test_cancel_stream_rejects_missing_stream ... ok
test test::test_cancel_stream_rejects_non_sender ... ok
test test::test_cancel_stream_rejects_already_inactive ... ok
test test::test_claimable_max_i128_rate_overflow ... ok
test test::test_cancel_while_paused_keeps_inactive ... ok
test test::test_completed_event_emitted_on_final_withdrawal ... ok
test test::test_concurrent_streams_same_tuple_independent_state ... ok
test test::test_create_multiple_streams_increments_id ... ok
test test::test_create_stream_invalid_token ... ok
test test::test_create_stream_max_i128_amount ... ok
test test::test_create_stream_emits_event ... ok
test test::test_create_stream_minimum_amount ... ok
test test::test_create_stream_minimum_duration ... ok
test test::test_create_stream_rate_exactly_one_succeeds ... ok
test test::test_create_stream_rejects_invalid_token_address ... ok
test test::test_create_stream_persists_state ... ok
test test::test_create_stream_rejects_negative_amount ... ok
test test::test_create_stream_rejects_zero_amount ... ok
test test::test_create_stream_rejects_zero_duration ... ok
test test::test_create_stream_self_stream ... ok
test test::test_create_stream_uses_ledger_timestamp_as_start_time ... ok
test test::test_create_stream_zero_rate ... ok
test test::test_create_stream_with_fee_deduction ... ok
test test::test_datakey_stream_counter_serializes_deterministically ... ok
test test::test_datakey_stream_serializes_deterministically ... ok
test test::test_fee_collected_event_emitted_on_create ... ok
test test::test_final_withdrawal_transitions_to_completed ... ok
test test::test_fuzz_cancel_early_refunds ... ok
test test::test_cumulative_fee_rounding_drift ... ok
test test::test_fuzz_claimable_overflow_and_cancel_invariants ... ok
test test::test_fuzz_large_amount_no_overflow ... ok
test test::test_fuzz_pause_resume_maintains_active_state ... ok
test test::test_fuzz_claimable_never_exceeds_remaining ... ok
test test::test_initialize_emits_event ... ok
test test::test_initialize_rejects_invalid_fee_rate ... ok
test test::test_initialize_rejects_second_call ... ok
test test::test_initialize_stores_config ... ok
test test::test_is_stream_completed_helper ... ok
test test::test_multiple_pause_resume_preserves_state ... ok
test test::test_no_fee_event_when_fee_rate_is_zero ... ok
test test::test_no_fee_transfer_or_event_when_fee_rounds_to_zero ... ok
test test::test_no_fee_without_protocol_config ... ok
test test::test_partial_withdrawal_does_not_complete ... ok
test test::test_pause_already_paused_stream_fails ... ok
test test::test_pause_by_non_sender_fails ... ok
test test::test_pause_emits_event ... ok
test test::test_pause_stops_accrual ... ok
test test::test_pause_stops_accrual_462 ... ok
test test::test_pause_stream_emits_event ... ok
test test::test_resume_adjusts_end_time ... ok
test test::test_resume_adjusts_last_update_time ... ok
test test::test_resume_emits_event ... ok
test test::test_resume_non_paused_stream_fails ... ok
test test::test_resume_stream_emits_event ... ok
test test::test_resume_then_cancel_settles_across_pause_boundary ... ok
test test::test_stream_created_event_field_names_match_decoder_expectations ... ok
test test::test_stream_id_uniqueness ... ok
test test::test_top_up_emits_event ... ok
test test::test_top_up_extends_stream ... ok
test test::test_top_up_increases_deposited_amount ... ok
test test::test_top_up_on_completed_stream ... ok
test test::test_top_up_preserves_already_accrued_claimable ... ok
test test::test_top_up_rejects_inactive_stream ... ok
test test::test_top_up_rejects_negative_amount ... ok
test test::test_top_up_rejects_nonexistent_stream ... ok
test test::test_top_up_rejects_unauthorized_sender ... ok
test test::test_top_up_rejects_zero_amount ... ok
test test::test_top_up_then_cancel_pays_pre_topup_accrued ... ok
test test::test_top_up_while_paused_does_not_advance_last_update_time ... ok
test test::test_top_up_while_paused_increases_deposited ... ok
test test::test_top_up_with_fee_deduction ... ok
test test::test_transfer_admin_emits_event ... ok
test test::test_transfer_admin_new_admin_can_update_fee_config ... ok
test test::test_transfer_admin_rejects_non_admin ... ok
test test::test_transfer_admin_rejects_not_initialized ... ok
test test::test_transfer_admin_succeeds ... ok
test test::test_update_fee_config_by_admin ... ok
test test::test_update_fee_config_emits_event ... ok
test test::test_update_fee_config_rejects_invalid_fee_rate ... ok
test test::test_update_fee_config_rejects_non_admin ... ok
test test::test_update_fee_config_rejects_not_initialized ... ok
test test::test_withdraw_accrued_amount ... ok
test test::test_withdraw_after_long_stream_runtime_is_bounded ... ok
test test::test_withdraw_caps_at_remaining_balance ... ok
test test::test_withdraw_emits_event ... ok
test test::test_withdraw_full_balance ... ok
test test::test_withdraw_on_paused_stream_fails ... ok
test test::test_withdraw_on_paused_stream_returns_stream_inactive ... ok
test test::test_fuzz_withdrawn_never_exceeds_deposited ... ok
test test::test_withdraw_on_paused_then_resume ... ok
test test::test_withdraw_rejects_inactive_stream ... ok
test test::test_withdraw_rejects_double_withdraw_after_completion ... ok
test test::test_withdraw_rejects_missing_stream ... ok
test test::test_withdraw_rejects_non_recipient ... ok
test test::test_withdraw_state_committed_before_transfer_prevents_double_payout ... ok
test test::test_withdraw_time_based_calculation ... ok
test test::test_withdraw_transfers_tokens_to_recipient ... ok
test test::test_withdraw_zero_balance ... ok

test result: ok. 117 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 13.43s (117 passed)
- 

Closes #1182
Closes #1183
Closes #1184
Closes #1185