### PR TITLE
refactor(backend): reuse Stellar public key regex

### DIFF
--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -1,7 +1,10 @@
 import type { Request, Response, NextFunction } from "express";
 import { prisma } from "../lib/prisma.js";
 import logger from "../logger.js";
-import { registerUserSchema } from "../validators/user.validator.js";
+import {
+  registerUserSchema,
+  STELLAR_PUBLIC_KEY_REGEX,
+} from "../validators/user.validator.js";
 import type { AuthenticatedRequest } from "../types/auth.types.js";
 import {
   DEFAULT_EVENTS_PAGE_SIZE,
@@ -103,7 +106,7 @@ export const getUser = async (
     if (typeof publicKey !== "string") {
       return res.status(400).json({ error: "Invalid publicKey parameter" });
     }
-    if (!/^G[A-Z2-7]{55}$/.test(publicKey)) {
+    if (!STELLAR_PUBLIC_KEY_REGEX.test(publicKey)) {
       return res
         .status(400)
         .json({ error: "Invalid Stellar public key format" });
@@ -137,7 +140,7 @@ export const getUserEvents = async (
     if (typeof publicKey !== "string") {
       return res.status(400).json({ error: "Invalid publicKey parameter" });
     }
-    if (!/^G[A-Z2-7]{55}$/.test(publicKey)) {
+    if (!STELLAR_PUBLIC_KEY_REGEX.test(publicKey)) {
       return res
         .status(400)
         .json({ error: "Invalid Stellar public key format" });
@@ -251,7 +254,7 @@ export const exportTransactions = async (
       ? addressParam[0]
       : addressParam;
 
-    if (!address || !/^G[A-Z2-7]{55}$/.test(address)) {
+    if (!address || !STELLAR_PUBLIC_KEY_REGEX.test(address)) {
       return res.status(400).json({ error: "Invalid Stellar address" });
     }
 


### PR DESCRIPTION
Closes #1272

## Summary

`backend/src/controllers/user.controller.ts` redeclared the Stellar public key pattern `/^G[A-Z2-7]{55}$/` inline instead of using `STELLAR_PUBLIC_KEY_REGEX`, which is already exported from `backend/src/validators/user.validator.ts:11`.

This PR imports the shared constant and uses it at every Stellar-address format check in the controller. The audit named two sites; a third had since appeared in `exportTransactions`, so all three are covered and no inline Stellar-address literal remains in the controller.

Behaviour is unchanged. The pattern is byte-for-byte the same, and the shared `RegExp` carries no `g`/`y` flag, so `lastIndex` is never advanced and `.test()` stays stateless across calls.

## Files changed

- `backend/src/controllers/user.controller.ts`
  - added `STELLAR_PUBLIC_KEY_REGEX` to the existing import from `../validators/user.validator.js`
  - `getUser` (line 109): inline regex -> `STELLAR_PUBLIC_KEY_REGEX.test(publicKey)`
  - `getUserEvents` (line 143): inline regex -> `STELLAR_PUBLIC_KEY_REGEX.test(publicKey)`
  - `exportTransactions` (line 257): inline regex -> `STELLAR_PUBLIC_KEY_REGEX.test(address)`

No new constant was introduced, the regex itself was not touched, and no other controller code was refactored.

## Tests run and actual results

All commands run from `backend/`:

```
npx prisma generate                 -> Generated Prisma Client (v7.4.1)
npm run build                       -> tsc completed with no errors
npx vitest run tests/user.controller.test.ts tests/user.validator.test.ts --coverage.enabled=false
                                    -> 2 files passed, 27 tests passed
npx vitest run --exclude='tests/integration/**' --coverage.enabled=false
                                    -> 40 files passed, 310 tests passed, 3 skipped
```

Existing `tests/user.controller.test.ts` already asserts the 400 responses for malformed public keys on `GET /users/:publicKey` and `GET /users/:publicKey/events`, and `tests/user.validator.test.ts` covers the shared regex, so no new test was added for a like-for-like constant substitution.

Note: running a vitest subset trips the repo's global 60% coverage threshold, which is a property of the subset, not a failure of these tests. Coverage was disabled for the runs above; the full unit suite passes as reported.

## Verification

```
$ grep -rn "G\[A-Z2-7\]" backend/src/controllers/
(no matches)
```

## Acceptance criteria

- [x] `STELLAR_PUBLIC_KEY_REGEX` is imported from the existing validator module
- [x] Both controller locations named in the audit use the shared constant (plus a third that appeared since)
- [x] No inline Stellar-address regex literal remains in the controller
- [x] Existing relevant tests pass (310 unit tests)
- [x] TypeScript build passes (`npm run build`)

## Out of scope

`frontend/src/lib/stellar.ts:8` and `frontend/src/lib/csv-parser.ts:47` also carry the same literal, but they live in a separate workspace that cannot import the backend validator. Left untouched to keep this PR scoped to #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
