### PR TITLE
fix(frontend): add focus management to wallet modal

### DIFF
--- a/frontend/src/components/wallet/WalletModal.test.tsx
+++ b/frontend/src/components/wallet/WalletModal.test.tsx
@@ -1,0 +1,185 @@
+import { useCallback, useState } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const useWalletMock = vi.fn();
+
+vi.mock("@/context/wallet-context", () => ({
+  useWallet: () => useWalletMock(),
+}));
+
+vi.mock("@stellar/freighter-api", () => ({
+  isConnected: vi.fn(async () => ({ isConnected: true })),
+}));
+
+import { WalletModal } from "./WalletModal";
+
+/**
+ * Mirrors how the modal is used in the app: a trigger button owns the open
+ * state, so focus restoration has a real element to return to.
+ */
+function ModalHarness() {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleClose = useCallback(() => setIsOpen(false), []);
+
+  return (
+    <>
+      <button type="button" onClick={() => setIsOpen(true)}>
+        Open wallet modal
+      </button>
+      {isOpen && <WalletModal onClose={handleClose} />}
+    </>
+  );
+}
+
+const openModal = async () => {
+  const user = userEvent.setup();
+  render(<ModalHarness />);
+
+  const trigger = screen.getByRole("button", { name: /open wallet modal/i });
+  await user.click(trigger);
+
+  const dialog = await screen.findByRole("dialog");
+
+  return { user, trigger, dialog };
+};
+
+describe("WalletModal keyboard accessibility", () => {
+  beforeEach(() => {
+    document.body.style.overflow = "";
+    useWalletMock.mockReturnValue({
+      wallets: [
+        {
+          id: "freighter",
+          name: "Freighter",
+          badge: "Extension",
+          description: "Direct browser wallet.",
+        },
+        {
+          id: "albedo",
+          name: "Albedo",
+          badge: "Web / Mobile",
+          description: "Popup wallet.",
+        },
+      ],
+      status: "disconnected",
+      selectedWalletId: null,
+      errorMessage: null,
+      connect: vi.fn(),
+      clearError: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    document.body.style.overflow = "";
+  });
+
+  it("moves focus into the dialog when it opens", async () => {
+    const { dialog } = await openModal();
+
+    await waitFor(() => {
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: /close wallet modal/i }),
+    );
+  });
+
+  it("keeps Tab focus inside the dialog and wraps at the last element", async () => {
+    const { user, dialog, trigger } = await openModal();
+
+    const focusable = Array.from(
+      dialog.querySelectorAll<HTMLElement>("a[href], button:not([disabled])"),
+    );
+    expect(focusable.length).toBeGreaterThan(1);
+
+    // One full cycle plus one extra tab, so the wrap at the end is exercised.
+    for (let i = 0; i <= focusable.length; i++) {
+      await user.tab();
+      expect(dialog.contains(document.activeElement)).toBe(true);
+      expect(document.activeElement).not.toBe(trigger);
+      expect(document.activeElement).not.toBe(document.body);
+    }
+
+    // Tabbing off the last element returns to the first, never to the trigger.
+    focusable[focusable.length - 1]?.focus();
+    await user.tab();
+    expect(document.activeElement).toBe(focusable[0]);
+  });
+
+  it("keeps Shift+Tab focus inside the dialog and wraps at the first element", async () => {
+    const { user, dialog, trigger } = await openModal();
+
+    const focusable = Array.from(
+      dialog.querySelectorAll<HTMLElement>("a[href], button:not([disabled])"),
+    );
+    expect(focusable.length).toBeGreaterThan(1);
+
+    for (let i = 0; i <= focusable.length; i++) {
+      await user.tab({ shift: true });
+      expect(dialog.contains(document.activeElement)).toBe(true);
+      expect(document.activeElement).not.toBe(trigger);
+      expect(document.activeElement).not.toBe(document.body);
+    }
+
+    // Shift+Tab off the first element returns to the last, never to the trigger.
+    focusable[0]?.focus();
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(focusable[focusable.length - 1]);
+  });
+
+  it("closes on Escape and restores focus to the element that opened it", async () => {
+    const { user, trigger, dialog } = await openModal();
+
+    // Focus has to actually leave the trigger, otherwise "restored" is vacuous.
+    await user.tab();
+    expect(dialog.contains(document.activeElement)).toBe(true);
+    expect(document.activeElement).not.toBe(trigger);
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("locks body scroll while open and releases it on close", async () => {
+    const { user } = await openModal();
+
+    expect(document.body.style.overflow).toBe("hidden");
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("does not close on Escape while a connection is in flight", async () => {
+    useWalletMock.mockReturnValue({
+      wallets: [
+        {
+          id: "freighter",
+          name: "Freighter",
+          badge: "Extension",
+          description: "Direct browser wallet.",
+        },
+      ],
+      status: "connecting",
+      selectedWalletId: "freighter",
+      errorMessage: null,
+      connect: vi.fn(),
+      clearError: vi.fn(),
+    });
+
+    const { user } = await openModal();
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/wallet/WalletModal.tsx
+++ b/frontend/src/components/wallet/WalletModal.tsx
@@ -7,11 +7,16 @@
  *
  * - Freighter: shows "Install Freighter" link when extension is absent.
  * - Dismiss via Escape key or backdrop click.
+ *
+ * Focus trapping, focus restoration, Escape handling and body-scroll locking
+ * all come from the shared `useModalDialog` hook, so this dialog behaves the
+ * same way as every other modal in the app.
  */
 
-import React, { useEffect, useCallback } from "react";
+import React, { useEffect } from "react";
 import { type WalletId } from "@/lib/wallet";
 import { useWallet } from "@/context/wallet-context";
+import { useModalDialog } from "@/hooks/useModalDialog";
 
 import { isConnected } from "@stellar/freighter-api";
 
@@ -31,6 +36,11 @@ export function WalletModal({ onClose }: WalletModalProps) {
 
   const isConnecting = status === "connecting";
   const [freighterInstalled, setFreighterInstalled] = React.useState(true);
+
+  // Escape-to-close, focus trapping, focus restoration and body-scroll
+  // locking. Closing stays disabled while a connection is in flight, matching
+  // the disabled close button and the guarded backdrop click below.
+  const dialogRef = useModalDialog({ onClose, isCloseDisabled: isConnecting });
 
   // The Freighter extension injects itself asynchronously.
   // We need to poll briefly after mount to reliably detect it.
@@ -53,29 +63,6 @@ export function WalletModal({ onClose }: WalletModalProps) {
     return () => clearInterval(interval);
   }, []);
 
-  // Close on Escape
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !isConnecting) {
-        onClose();
-      }
-    },
-    [isConnecting, onClose],
-  );
-
-  useEffect(() => {
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [handleKeyDown]);
-
-  // Prevent body scroll while modal is open
-  useEffect(() => {
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, []);
-
   const handleConnect = async (walletId: WalletId) => {
     clearError();
     await connect(walletId);
@@ -95,7 +82,7 @@ export function WalletModal({ onClose }: WalletModalProps) {
       aria-labelledby="wallet-modal-title"
       onClick={handleBackdropClick}
     >
-      <div className="wallet-modal">
+      <div ref={dialogRef} className="wallet-modal">
         {/* Header */}
         <div className="wallet-modal__header">
           <div>


### PR DESCRIPTION
Closes #1257

## Summary

`frontend/src/components/wallet/WalletModal.tsx` implemented its own Escape handler and body-scroll lock but had no focus trap and no focus restoration. Tab walked straight out of the open dialog into the page behind it, and closing the modal dropped focus on `document.body`.

This PR migrates the modal to the repository's existing `useModalDialog` hook, the same one already used by `TopUpModal`, `CancelConfirmModal`, `StreamDetailsModal`, `StreamCreationWizard` and the navbar's `MobileMenu`. No new focus-trap mechanism was written.

## Accessibility changes

- `useModalDialog({ onClose, isCloseDisabled: isConnecting })` replaces the bespoke `useCallback` + `document.addEventListener("keydown", ...)` Escape handler and the standalone body-scroll-lock effect.
- `dialogRef` is attached to the inner `.wallet-modal` panel, matching how `TopUpModal` and `CancelConfirmModal` place it (`role="dialog"` stays on the backdrop).
- Focus now moves into the dialog on open, Tab wraps from the last focusable back to the first, Shift+Tab wraps from the first back to the last, and closing restores focus to the element that opened the modal.
- `isCloseDisabled` is wired to `isConnecting`, preserving the existing rule that the modal cannot be dismissed mid-connection. That already matched the disabled close button and the guarded backdrop click.

Wallet selection, `connect`/`clearError` calls, the Freighter detection poll, the install-link fallback, error banner, props, state and styling are untouched.

## Files changed

- `frontend/src/components/wallet/WalletModal.tsx` (+12 / -25)
- `frontend/src/components/wallet/WalletModal.test.tsx` (new)

## Tests run and actual results

New `WalletModal.test.tsx` covers the acceptance criteria directly, using `@testing-library/user-event` against a harness with a real trigger button:

1. focus moves into the dialog on open
2. Tab through a full cycle plus one, asserting focus never lands on the trigger or `document.body`, and wraps last -> first
3. the same for Shift+Tab, wrapping first -> last
4. Escape closes and focus returns to the trigger (after first asserting focus had actually left it)
5. body scroll locks on open and releases on close
6. Escape is ignored while `status === "connecting"`

All commands run from `frontend/`:

```
npx vitest run src/components/wallet/WalletModal.test.tsx src/hooks/useModalDialog.test.tsx src/__tests__/wallet-entry.test.tsx
    -> 3 files passed, 15 tests passed

npx vitest run
    -> 27 files passed, 239 tests passed

npm run lint
    -> 0 errors, 1 pre-existing warning in src/components/dashboard/ActivityHistory.tsx (unrelated)

npm run build
    -> Compiled successfully, TypeScript finished, 13/13 static pages generated
```

Verification that the tests catch the actual bug: with `WalletModal.tsx` stashed back to its pre-migration state, tests 1, 2 and 3 fail (`3 failed | 3 passed`). They pass with the migration applied.

## Acceptance criteria

- [x] `WalletModal` uses `useModalDialog`
- [x] Bespoke Escape handling removed (the hook provides it, gated by `isCloseDisabled`)
- [x] Bespoke body-scroll locking removed (the hook provides it)
- [x] Tab cannot move focus outside the modal
- [x] Shift+Tab cannot move focus outside the modal
- [x] Closing the modal restores focus to the triggering element
- [x] Keyboard-navigation test added and passing
- [x] Existing `useModalDialog` and `wallet-entry` tests still pass; full frontend suite green (239 tests)
- [x] Lint and `next build` pass

## Pre-existing issues found, not fixed here

Out of scope for this PR, recorded rather than touched:

- `npx tsc --noEmit` reports 27 errors, all in existing test files (`src/lib/api/streams.test.ts`, `src/hooks/useIncomingStreams.test.tsx`, `src/app/streams/create/__tests__/create-stream-content.test.tsx`). They predate this branch; `next build` does not type-check those files, so CI is unaffected.
- `src/components/dashboard/ActivityHistory.tsx:26` emits a `react-hooks/incompatible-library` lint warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
