### PR TITLE
feat(backend): add calculatedAt metric freshness indicator (Closes #1240)

### DIFF
--- a/backend/src/routes/v1/admin.routes.ts
+++ b/backend/src/routes/v1/admin.routes.ts
@@ -169,6 +169,22 @@ function withLiveIndexerCounters<
   };
 }
 
+/**
+ * Attach a `calculatedAt` timestamp reflecting when the underlying aggregation
+ * actually ran (i.e. when the metrics payload was stored in the cache), not
+ * when this HTTP response is serialized. On a cache HIT this stays stable
+ * across requests served from the same cache entry (Issue #1240).
+ */
+function withCalculatedAt<T extends object>(
+  payload: T,
+): T & { calculatedAt: string } {
+  const createdAt = cache.getMetadata(ADMIN_METRICS_CACHE_KEY)?.createdAt;
+  return {
+    ...payload,
+    calculatedAt: createdAt ?? new Date().toISOString(),
+  };
+}
+
 router.get('/metrics', async (_req: Request, res: Response) => {
   try {
     const cached = cache.get<Awaited<ReturnType<typeof buildAdminMetrics>>>(
@@ -176,14 +192,14 @@ router.get('/metrics', async (_req: Request, res: Response) => {
     );
     if (cached) {
       res.set('X-Cache', 'HIT');
-      res.json(withLiveIndexerCounters(cached));
+      res.json(withLiveIndexerCounters(withCalculatedAt(cached)));
       return;
     }
 
     const payload = await buildAdminMetrics();
     cache.set(ADMIN_METRICS_CACHE_KEY, payload, ADMIN_METRICS_CACHE_TTL_SECONDS);
     res.set('X-Cache', 'MISS');
-    res.json(payload);
+    res.json(withCalculatedAt(payload));
   } catch (err) {
     logger.error('Error fetching admin metrics:', err);
     res.status(500).json({ error: 'Internal server error' });

--- a/backend/tests/integration/admin-metrics.test.ts
+++ b/backend/tests/integration/admin-metrics.test.ts
@@ -333,6 +333,72 @@ describe('GET /v1/admin/metrics', () => {
       degraded: true,
     });
   });
+
+  it('includes a calculatedAt timestamp in valid ISO 8601 format (#1240)', async () => {
+    setupCounts({ total: 5, active: 3 });
+    mocks.cache.getMetadata.mockReturnValue({
+      createdAt: '2026-08-01T00:00:00.000Z',
+      expiresAt: '2026-08-01T00:01:00.000Z',
+    });
+
+    const res = await request(app)
+      .get('/v1/admin/metrics')
+      .set('Authorization', `Bearer ${createToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body.calculatedAt).toBe('string');
+    expect(res.body.calculatedAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    );
+    expect(Date.parse(res.body.calculatedAt)).not.toBeNaN();
+    // Reflects when the aggregation ran, not when the response was serialized.
+    expect(res.body.calculatedAt).toBe('2026-08-01T00:00:00.000Z');
+    expect(res.body.calculatedAt).not.toBe(new Date().toISOString());
+  });
+
+  it('keeps calculatedAt stable across responses served from the same cache entry (#1240)', async () => {
+    const cachedPayload = {
+      total_streams: 99,
+      active_streams: 50,
+      paused_streams: 5,
+      completed_streams: 30,
+      cancelled_streams: 14,
+      total_volume_streamed: '123456789',
+      indexer: {
+        lastLedger: 10,
+        lagSeconds: 1,
+        lastUpdated: null,
+        eventsProcessed: 0,
+        eventsFailed: 0,
+        lastErrorAt: null,
+        degraded: false,
+      },
+    };
+    const aggregationTime = '2026-08-01T00:00:00.000Z';
+    mocks.cache.get.mockReturnValue(cachedPayload);
+    mocks.cache.getMetadata.mockReturnValue({
+      createdAt: aggregationTime,
+      expiresAt: '2026-08-01T00:01:00.000Z',
+    });
+
+    const first = await request(app)
+      .get('/v1/admin/metrics')
+      .set('Authorization', `Bearer ${createToken()}`);
+    const second = await request(app)
+      .get('/v1/admin/metrics')
+      .set('Authorization', `Bearer ${createToken()}`);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(first.headers['x-cache']).toBe('HIT');
+    expect(second.headers['x-cache']).toBe('HIT');
+    // Both requests served from the same cache entry: calculatedAt must equal
+    // the aggregation time and must NOT drift to "now" on each call.
+    expect(first.body.calculatedAt).toBe(aggregationTime);
+    expect(second.body.calculatedAt).toBe(aggregationTime);
+    expect(second.body.calculatedAt).toEqual(first.body.calculatedAt);
+    expect(second.body.calculatedAt).not.toBe(new Date().toISOString());
+  });
 });
 
 describe('GET /v1/admin/indexer/status', () => {


### PR DESCRIPTION
## Description

Adds a visible stale/cached indicator to the admin metrics dashboard by including a `calculatedAt` ISO-8601 timestamp in the `GET /v1/admin/metrics` response. The timestamp reflects when the underlying aggregation actually ran (when the metrics payload was stored in the in-process cache), not when the HTTP response is serialized. This lets operators/dashboards tell whether the numbers reflect the last few seconds or up to the full cache TTL (60s) ago.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧪 Test addition or update

## Related Issues

Closes #1240

## Changes Made

The metrics cache (`MemoryCache`, `backend/src/lib/redis.ts`) already records the timestamp at which each cache entry was populated (`createdAt`, exposed via `cache.getMetadata()`). No new caching pattern was invented — this reuses the same convention already used by `claimable.service.ts` (`cachedAt`).

Changed files:

- `backend/src/routes/v1/admin.routes.ts`
  - Added `withCalculatedAt()` helper that reads `cache.getMetadata(ADMIN_METRICS_CACHE_KEY).createdAt` and attaches a `calculatedAt` field (falling back to the current time only if metadata is unavailable).
  - Applied it on both the cache-`HIT` path (behind `withLiveIndexerCounters`) and the cache-`MISS` path.
- `backend/tests/integration/admin-metrics.test.ts`
  - Added a test asserting `calculatedAt` is present in valid ISO 8601 format.
  - Added a test asserting `calculatedAt` reflects the aggregation time and is stable across multiple responses served from the same cache entry (does not drift to "now" on every call).

## Acceptance Criterion

"The `/v1/admin/metrics` response includes a timestamp field reflecting when the underlying aggregation ran."

Met as follows:

- On a cache `MISS`, `buildAdminMetrics()` runs and the result is stored via `cache.set(ADMIN_METRICS_CACHE_KEY, payload, 60)`. The cache entry's `createdAt` is that store time, i.e. when the aggregation actually ran. `calculatedAt` is derived from it.
- On a cache `HIT`, the cached payload is served and `calculatedAt` is still derived from the same cache entry's `createdAt`, so two consecutive requests within the 60s TTL return the **same** `calculatedAt` — proven by the new stability test. It is never recomputed as "now" at response-serialization time on a cache hit.

## Testing

### Test Coverage

- [x] Integration tests added/updated
- [x] Manual testing performed (local CI-equivalent checks)

### Commands & Real Results

Backend has no lint script (`backend/package.json` has no `lint`); `.github/workflows/ci.yml` runs `npm run build` + `npx vitest run --coverage --reporter=basic` for the backend. Frontend lint also runs in CI but no frontend files are touched here.

`npm run build` (backend — includes `tsc` type-check):

```
> backend@1.0.0 prebuild
> prisma generate
✔ Generated Prisma Client (v7.4.1) to .\src\generated\prisma

> backend@1.0.0 build
> tsc
EXIT=0
```

Targeted test file:
```
✓ tests/integration/admin-metrics.test.ts (20 tests) 1791ms
Test Files  1 passed (1)
     Tests  20 passed (20)
```

Full backend suite (CI-equivalent: `npx vitest run --coverage --reporter=basic`; real-Postgres integration tests self-skip locally because Docker/`DATABASE_URL` are unavailable — they run in CI):
```
Test Files  51 passed (51)
     Tests  381 passed | 16 skipped (397)
All files  | 66.39 | 74.52 | 70.83 | 66.39
  backend/src/routes/v1/admin.routes.ts | 90.72 | 75.86 | 100 | 90.72
```
Coverage thresholds (60%) all pass. The only uncleanness in the local run is a pre-existing unhandled rejection in `tests/workers.index.test.ts` (`stream-runway-worker` logger mock, `default.error is not a function`) that also reproduces on the clean base branch with these changes stashed; it does not fail any test.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked for breaking changes and documented them if applicable