### PR TITLE
Fix overlapping stream fetches by tracking request ids

### DIFF
--- a/frontend/src/app/streams/[id]/stream-details-content.tsx
+++ b/frontend/src/app/streams/[id]/stream-details-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import Link from "next/link";
 import { getApiBaseUrl } from "@/lib/api/_shared";
 import { logger } from "@/lib/logger";
@@ -92,21 +92,29 @@ export default function StreamDetailsContent({ streamId }: { streamId: string })
     autoReconnect: true,
   });
 
+  const streamReqId = useRef(0);
   const fetchStream = useCallback(async (signal?: AbortSignal) => {
     if (!streamId) return;
+    const reqId = ++streamReqId.current;
     try {
       const response = await fetch(`${API_BASE_URL}/streams/${streamId}`, { signal });
       if (!response.ok) throw new Error("Stream not found");
       const data = await response.json();
-      setStream(data);
+      if (reqId === streamReqId.current) {
+        setStream(data);
+      }
     } catch (err) {
       if (err instanceof Error && err.name === "AbortError") return;
-      setError(err instanceof Error ? err.message : "Failed to fetch stream");
+      if (reqId === streamReqId.current) {
+        setError(err instanceof Error ? err.message : "Failed to fetch stream");
+      }
     }
   }, [streamId]);
 
+  const eventsReqId = useRef(0);
   const fetchEvents = useCallback(async (page: number, signal?: AbortSignal) => {
     if (!streamId) return;
+    const reqId = ++eventsReqId.current;
     try {
       const response = await fetch(
         `${API_BASE_URL}/streams/${streamId}/events?page=${page}&limit=${EVENTS_PER_PAGE}`,
@@ -114,8 +122,10 @@ export default function StreamDetailsContent({ streamId }: { streamId: string })
       );
       if (response.ok) {
         const data = await response.json();
-        setEvents(data.events || []);
-        setEventsTotal(data.total || 0);
+        if (reqId === eventsReqId.current) {
+          setEvents(data.events || []);
+          setEventsTotal(data.total || 0);
+        }
       }
     } catch (err) {
       if (err instanceof Error && err.name === "AbortError") return;


### PR DESCRIPTION
## Description
Fixes an issue where overlapping fetch requests for stream details and events (caused by rapid SSE bursts) could resolve out of order and apply stale data. Previously, the refresh effect created a new `AbortController` on each update, but this didn't prevent an already in-flight, slower fetch from resolving late and overwriting newer state data within the same mount.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update

## Related Issues
Closes #1212 

## Changes Made
- Implemented monotonic request ID tracking using `useRef` for both `fetchStream` and `fetchEvents` in `frontend/src/app/streams/[id]/stream-details-content.tsx`.
- Updated state setters within the `fetchStream` and `fetchEvents` callbacks to check that the current request ID matches the latest request ID before applying the fetched data to state, safely discarding outdated overlapping responses.

## Testing
### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Steps
1. Navigate to a stream details page.
2. Trigger two rapid, sequential SSE events to the stream in quick succession.
3. Simulate or observe a scenario where the first request's latency exceeds the second request's latency.
4. Verify that the UI ultimately renders the data from the final, most recent event without rolling back to stale data from the delayed first fetch.

## Breaking Changes
**Breaking Changes:**
- None

**Migration Guide:**
- N/A

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Updated Postman/Hoppscotch API collections if routes changed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have checked for breaking changes and documented them if applicable

## Additional Notes
By explicitly tracking request IDs manually on the callbacks instead of heavily restructuring the `useEffect` scope for aborts, this prevents overlapping state updates directly regardless of where the fetch callbacks are invoked from (e.g. initial loads, manual top-ups, SSE events).
