### PR TITLE
Add Accessible Label to Custom Template Name Input

### DIFF
--- a/frontend/src/components/stream-creation/TemplateStep.tsx
+++ b/frontend/src/components/stream-creation/TemplateStep.tsx
@@ -101,7 +101,14 @@ export const TemplateStep: React.FC<TemplateStepProps> = ({
           Save your current amount, duration, token, and tag to reuse later.
         </p>
         <div className="flex flex-col md:flex-row gap-3">
+          <label
+            htmlFor="custom-template-name"
+            className="block text-sm font-medium mb-2 text-foreground"
+          >
+            Template name
+          </label>
           <input
+            id="custom-template-name"
             type="text"
             value={customTemplateName}
             onChange={(e) => onCustomTemplateNameChange(e.target.value)}


### PR DESCRIPTION
##closed #1259 

Improve the accessibility of the custom template name field in TemplateStep.tsx by providing a proper accessible name for the input.

The input currently relies only on placeholder="Template name", which is not a reliable substitute for a label because placeholder text disappears when users enter a value and may not be properly announced by screen readers.
Follow the existing accessible-input pattern used in RecipientStep.tsx by adding a visible label or an appropriate aria-label.

Scope:
  Update frontend/src/components/stream-creation/TemplateStep.tsx.
  Add an accessible name to the custom template name input.
  Follow the existing labeling pattern used in RecipientStep.tsx.
  Ensure the accessibility check no longer reports a missing accessible name.
  Do not change the field's existing functionality or behaviour.