### PR TITLE
fix: prevent confirming state from immediately reverting in stream creation

### DIFF
--- a/frontend/src/app/streams/create/create-stream-content.tsx
+++ b/frontend/src/app/streams/create/create-stream-content.tsx
@@ -178,18 +178,19 @@ export default function CreateStreamContent() {
 
       if (result.success) {
         setTxState("confirming");
-        clearDraft(); // Clear draft on successful submission
+        clearDraft();
         toast.success("Stream created successfully!");
         setTimeout(() => {
+          setLoading(false);
+          setTxState("idle");
           router.push("/dashboard");
         }, 2000);
       }
     } catch (error) {
-      logger.error("Stream creation failed:", error);
-      toast.error(toSorobanErrorMessage(error));
-    } finally {
       setLoading(false);
       setTxState("idle");
+      logger.error("Stream creation failed:", error);
+      toast.error(toSorobanErrorMessage(error));
     }
   };
 


### PR DESCRIPTION
## Problem
After successfully submitting a stream creation, the UI was supposed to show a "Finalizing Stream..." state for 2 seconds before navigating to the dashboard. However, the `finally` block in the `handleSubmit` function was executing synchronously immediately after the `try` block completed, resetting `setLoading(false)` and `setTxState("idle")` before React could even render the confirming state.

This caused the button to flash past "Finalizing Stream..." and instantly revert to "Start Streaming", creating a glitchy user experience.

## Root Cause
In `create-stream-content.tsx:179-194`, the `finally` block at lines 190-193 was placed outside the `setTimeout` callback, causing it to execute immediately after the async operation completed rather than waiting for the 2-second delay.

## Solution
Moved the state reset logic from the `finally` block to the appropriate locations:

1. **Success path**: Moved `setLoading(false)` and `setTxState("idle")` inside the `setTimeout` callback, just before `router.push("/dashboard")`. This ensures the confirming state persists for the full 2 seconds before cleaning up and navigating.

2. **Error path**: Added the same state reset to the `catch` block so loading state is properly cleared on failure.

## Changes
- `frontend/src/app/streams/create/create-stream-content.tsx:179-194`
  - Removed the `finally` block
  - Added state cleanup in `setTimeout` callback (success path)
  - Added state cleanup in `catch` block (error path)

## Testing
All existing tests pass (286/286 across 32 test files). The change is minimal and focused on the state management timing, which is now correctly handled.

## Impact
Fixes a visibly glitchy state transition on the primary stream-creation flow, improving the user experience by ensuring the "Finalizing Stream..." message is visible for the intended duration.

Closes #1231
