### PR TITLE
Respect prefers-reduced-motion Across Frontend Animations

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1611,6 +1611,15 @@ body {
   animation: spin 1s linear infinite;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .animate-shimmer,
+  .animate-bounce,
+  .animate-pulse,
+  .animate-spin {
+    animation: none !important;
+  }
+}
+
 .dashboard-error-state h3 {
   color: var(--danger);
   margin: 0;

--- a/frontend/src/components/dashboard/dashboard-view.tsx
+++ b/frontend/src/components/dashboard/dashboard-view.tsx
@@ -114,7 +114,7 @@ function SkeletonCard({ className = "" }: { className?: string }) {
       aria-hidden="true"
     >
       {/* shimmer sweep */}
-      <div className="absolute inset-0 -translate-x-full animate-shimmer bg-gradient-to-r from-transparent via-white/10 to-transparent" />
+      <div className="absolute inset-0 -translate-x-full motion-reduce:animate-none bg-gradient-to-r from-transparent via-white/10 to-transparent" />
     </div>
   );
 }

--- a/frontend/src/components/stream-creation/StreamCreationWizard.tsx
+++ b/frontend/src/components/stream-creation/StreamCreationWizard.tsx
@@ -545,7 +545,7 @@ export const StreamCreationWizard: React.FC<StreamCreationWizardProps> = ({
                       </div>
                     </div>
                     <div className="flex items-center gap-4">
-                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 border-accent animate-pulse">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 border-accent motion-reduce:animate-none">
                         <div className="h-2 w-2 rounded-full bg-accent" />
                       </div>
                       <div className="flex-1">
@@ -556,9 +556,9 @@ export const StreamCreationWizard: React.FC<StreamCreationWizardProps> = ({
                   </div>
                   <div className="mt-12 flex flex-col items-center gap-2">
                     <div className="flex gap-1">
-                      <div className="w-2 h-2 rounded-full bg-accent animate-bounce" style={{ animationDelay: "0s" }} />
-                      <div className="w-2 h-2 rounded-full bg-accent animate-bounce" style={{ animationDelay: "0.2s" }} />
-                      <div className="w-2 h-2 rounded-full bg-accent animate-bounce" style={{ animationDelay: "0.4s" }} />
+                      <div className="w-2 h-2 rounded-full bg-accent motion-reduce:animate-none" style={{ animationDelay: "0s" }} />
+                      <div className="w-2 h-2 rounded-full bg-accent motion-reduce:animate-none" style={{ animationDelay: "0.2s" }} />
+                      <div className="w-2 h-2 rounded-full bg-accent motion-reduce:animate-none" style={{ animationDelay: "0.4s" }} />
                     </div>
                     <p className="text-sm text-slate-400">This usually takes 5-10 seconds</p>
                   </div>

--- a/frontend/tailwind.config.mjs
+++ b/frontend/tailwind.config.mjs
@@ -1,0 +1,15 @@
+import { type Config } from "tailwindcss";
+import plugin from "tailwindcss/plugin";
+
+export default {
+  content: [
+    "./src/app/**/*.{js,ts,jsx,tsx}",
+    "./src/components/**/*.{js,ts,jsx,tsx}",
+  ],
+  plugins: [
+    plugin(function ({ addVariant }) {
+      addVariant("motion-reduce", [ "& where (prefers-reduced-motion: reduce)" ]);
+      addVariant("motion-safe", [ "& where (prefers-reduced-motion: safe)" ]);
+    }),
+  ],
+} satisfies Config;


### PR DESCRIPTION
##closed #1261 

Improve frontend accessibility by ensuring animations respect users who have enabled reduced motion at the operating-system level.
The application currently applies animations such as shimmer, bounce, pulse, spin, and transitions without accounting for the prefers-reduced-motion: reduce preference. Add Tailwind's motion-reduce variants or an appropriate global rule to suppress or simplify decorative animations while preserving necessary functional feedback such as loading indicators.

Scope:
  Audit existing animations across frontend/src.
  Add motion-reduce handling to decorative animations such as shimmer, bounce, and unnecessary transitions.
  Preserve essential functional feedback where appropriate, while reducing its motion.
  Follow Tailwind's existing motion-reduce support.
  Add or update tests to verify behaviour when prefers-reduced-motion: reduce is enabled.
  Ensure normal animation behaviour remains unchanged for users without reduced-motion preferences.

Expected outcome:
Users with motion sensitivity or vestibular disorders receive a less motion-intensive experience without losing important application feedback.