### PR TITLE
Remove Redundant streamId Index from Stream Model

### DIFF
--- a/backend/prisma/migrations/20260830000000_remove_redundant_streamid_index/migration.sql
+++ b/backend/prisma/migrations/20260830000000_remove_redundant_streamid_index/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX IF EXISTS "Stream_streamId_idx";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -52,7 +52,6 @@ model Stream {
   @@index([sender])
   @@index([recipient])
   @@index([tokenAddress])
-  @@index([streamId])
   @@index([isActive])
   @@index([isPaused])
 }


### PR DESCRIPTION
##closed #1247

Remove the redundant database index on Stream.streamId in backend/prisma/schema.prisma.

The streamId BigInt @unique constraint already creates a unique index that can efficiently support lookups on streamId. The additional @@index([streamId]) provides no query benefit while adding unnecessary storage and write overhead.

Scope:
  Remove the redundant @@index([streamId]) from the Stream model.
  Generate the corresponding Prisma migration to drop the redundant index.
  Preserve the existing @unique constraint on streamId.
  Verify that streamId lookups continue to use an index scan.
  Do not change application behaviour or query logic.

Expected outcome:
The Stream table uses the existing unique index for streamId lookups, reducing unnecessary index maintenance and storage without affecting query performance.