### PR TITLE
fix: correct misleading docstring claiming claimable-amount cache is …

### DIFF
--- a/backend/src/lib/redis.ts
+++ b/backend/src/lib/redis.ts
@@ -1,6 +1,10 @@
 /**
- * Redis / In-Memory Cache Service
- * Used for horizontal SSE scaling and claimable amount caching (Issue #377)
+ * Redis Pub/Sub Service and Per-Instance Memory Cache
+ *
+ * Redis (when configured) provides horizontal SSE scaling via pub/sub.
+ * The claimable-amount cache is a per-process in-memory Map (MemoryCache),
+ * NOT Redis-backed.  Each instance computes and caches independently, so
+ * cached values are not shared across horizontal replicas.
  */
 import { Redis } from 'ioredis';
 import logger from '../logger.js';
@@ -11,7 +15,9 @@ let _publisher: Redis | null = null;
 let _subscriber: Redis | null = null;
 let _available = false;
 
-// --- Memory Cache for Claimable Amounts (Issue #377) ---
+// --- Per-Instance In-Memory Cache for Claimable Amounts (Issue #377) ---
+// NOTE: This cache lives in-process only. It is NOT shared via Redis and
+// will not be consistent across horizontally scaled instances.
 interface CacheItem<T> {
   value: T;
   expiresAt: number;


### PR DESCRIPTION
## Summary

Correct misleading docstrings and comments in `backend/src/lib/redis.ts` that imply the claimable-amount cache is Redis-backed, when it is actually a per-process in-memory `Map`.

## Problem

The module docstring said "Used for horizontal SSE scaling and claimable amount caching" — grouping two unrelated subsystems. The claimable-amount cache is a `MemoryCache` (plain `Map`), not Redis-backed. In a multi-instance deployment, each instance caches independently, so the naming is architecturally misleading.

## Changes

**`backend/src/lib/redis.ts`**:
- Updated the module docstring to clearly separate Redis pub/sub (horizontal SSE scaling) from the in-memory claimable-amount cache.
- Added an inline comment on the `MemoryCache` block stating it is per-process only and not shared across instances.

No functional changes — purely documentation corrections.

---

Closes #1276