### PR TITLE
feat: add optimizePackageImports for tree-shaking in Next.js build

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Enable tree-shaking for icon/utility libraries to reduce per-route
+  // bundle sizes (Issue #1254).
+  experimental: {
+    optimizePackageImports: [
+      "lucide-react",
+      "@tanstack/react-query",
+      "@tanstack/react-virtual",
+    ],
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
## Summary

Add `experimental.optimizePackageImports` to the Next.js config for `lucide-react`, `@tanstack/react-query`, and `@tanstack/react-virtual` to enable barrel-file tree-shaking and reduce per-route bundle sizes.

## Problem

`frontend/next.config.ts` had no code-splitting or tree-shaking configuration for icon/utility libraries. Combined with no `dynamic()`/`lazy()` usage, every route ships as one large bundle.

## Changes

**`frontend/next.config.ts`**:
- Added `experimental.optimizePackageImports` listing the three barrel-exported packages the frontend imports from.

```ts
experimental: {
  optimizePackageImports: [
    "lucide-react",
    "@tanstack/react-query",
    "@tanstack/react-virtual",
  ],
},

Closes #1254

