### PR TITLE
Prevent State Updates After WalletModal Unmount

### DIFF
--- a/frontend/src/components/wallet/WalletModal.tsx
+++ b/frontend/src/components/wallet/WalletModal.tsx
@@ -44,10 +44,12 @@ export function WalletModal({ onClose }: WalletModalProps) {
 
   // The Freighter extension injects itself asynchronously.
   // We need to poll briefly after mount to reliably detect it.
+  const cancelled = React.useRef(false);
   useEffect(() => {
     let attempts = 0;
     const interval = setInterval(async () => {
       const res = await isConnected();
+      if (cancelled.current) return;
       if (res.isConnected) {
         setFreighterInstalled(true);
         clearInterval(interval);
@@ -60,7 +62,10 @@ export function WalletModal({ onClose }: WalletModalProps) {
       }
     }, 100);
 
-    return () => clearInterval(interval);
+    return () => {
+      cancelled.current = true;
+      clearInterval(interval);
+    };
   }, []);
 
   const handleConnect = async (walletId: WalletId) => {


### PR DESCRIPTION
##closed #1211

Fix the asynchronous polling in WalletModal.tsx to prevent setFreighterInstalled from being called after the component has unmounted.
The modal currently polls isConnected() every 100ms. Although the interval is cleared during cleanup, an isConnected() call that is already in progress can still resolve afterward and trigger a state update on the unmounted component.

Scope:
  Add a cancellation flag/ref to track whether the component has been unmounted.
  Set the cancellation flag during the effect cleanup.
  Check the flag before calling setFreighterInstalled.
  Add a test using fake timers to reproduce closing the modal while a poll is in flight.
  Verify no state-update-after-unmount warning occurs.
  Preserve the existing polling behaviour while the component remains mounted.

Expected outcome:
WalletModal safely handles in-flight connection checks and no longer attempts to update state after unmounting.