### PR TITLE
fix: unify live claimable amount ticking via useStreamingAmount (fixes #1267)

### DIFF
--- a/frontend/src/app/streams/[id]/__tests__/stream-details-content.test.tsx
+++ b/frontend/src/app/streams/[id]/__tests__/stream-details-content.test.tsx
@@ -37,6 +37,13 @@ vi.mock("@/hooks/useStreamEvents", () => ({
   useStreamEvents: () => ({ events: [] }),
 }));
 
+// The shared ticking hook is exercised by its own suite
+// (frontend/src/__tests__/useStreamingAmount.test.tsx); here we only verify
+// that the details page wires it into the "Claimable" stat card.
+vi.mock("@/hooks/useStreamingAmount", () => ({
+  useStreamingAmount: () => 123456789, // 12.3456789 XLM in stroops
+}));
+
 vi.mock("@/lib/soroban", () => ({
   withdrawFromStream: vi.fn(),
   cancelStream: vi.fn(),
@@ -181,5 +188,27 @@ describe("StreamDetailsContent loading skeleton", () => {
 
     // The not-found/error UI should have a back link
     expect(screen.getByText(/← back to dashboard/i)).toBeInTheDocument();
+  });
+
+  it("renders the live claimable amount from the shared useStreamingAmount hook", async () => {
+    const mockStream = createMockStream();
+
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockStream,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ events: [], total: 0 }),
+      } as Response);
+
+    render(<StreamDetailsContent streamId={STREAM_ID} />);
+
+    // Once the stream loads, the Claimable stat card should show the value
+    // returned by the shared hook, formatted in token units (stroops → XLM).
+    await waitFor(() => {
+      expect(screen.getByText(/12\.3456789 XLM/)).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/app/streams/[id]/stream-details-content.tsx
+++ b/frontend/src/app/streams/[id]/stream-details-content.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/Button";
 import toast from "react-hot-toast";
 import { useWallet } from "@/context/wallet-context";
 import { useStreamEvents } from "@/hooks/useStreamEvents";
+import { useStreamingAmount } from "@/hooks/useStreamingAmount";
 import TransactionTracker, {
   useTransactionTracker,
 } from "@/components/TransactionTracker";
@@ -85,7 +86,25 @@ export default function StreamDetailsContent({ streamId }: { streamId: string })
   const [showTopUp, setShowTopUp] = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
 
-  const [liveClaimable, setLiveClaimable] = useState<bigint>(0n);
+  // Shared, visibility-aware claimable ticking (rAF-based, pauses when the
+  // tab is hidden) — same hook the dashboard uses, so both pages compute the
+  // "live claimable amount" through one implementation. See issue #1267.
+  const liveClaimableNumber = useStreamingAmount({
+    deposited: stream ? Number(stream.depositedAmount) : 0,
+    withdrawn: stream ? Number(stream.withdrawnAmount) : 0,
+    ratePerSecond: stream ? Number(stream.ratePerSecond) : 0,
+    lastUpdateTime: stream?.lastUpdateTime,
+    isActive: stream?.isActive ?? false,
+    isPaused: stream?.isPaused ?? false,
+    pausedAt: stream?.pausedAt != null ? Number(stream.pausedAt) : null,
+  });
+
+  // The hook operates on numbers (same as the dashboard), but this page
+  // formats raw stroop amounts, so round back to an exact bigint for display.
+  const liveClaimable = useMemo(() => {
+    if (!Number.isFinite(liveClaimableNumber)) return 0n;
+    return BigInt(Math.round(liveClaimableNumber));
+  }, [liveClaimableNumber]);
 
   const { events: streamEvents } = useStreamEvents({
     streamIds: [streamId],
@@ -158,38 +177,8 @@ export default function StreamDetailsContent({ streamId }: { streamId: string })
       }
     };
 
-    refreshStreamData();
-
-    return () => controller.abort();
+    refreshStreamData();    return () => controller.abort();
   }, [streamEvents, fetchStream, fetchEvents, eventsPage]);
-
-  useEffect(() => {
-    if (!stream) return;
-
-    const ratePerSecond = BigInt(stream.ratePerSecond);
-    const withdrawn = BigInt(stream.withdrawnAmount);
-    const deposited = BigInt(stream.depositedAmount);
-    const lastUpdate = stream.lastUpdateTime;
-
-    const updateClaimable = () => {
-      if (!stream.isActive || stream.isPaused) {
-        setLiveClaimable(deposited - withdrawn);
-        return;
-      }
-
-      const now = Math.floor(Date.now() / 1000);
-      const elapsed = BigInt(now - lastUpdate);
-      const accrued = elapsed * ratePerSecond;
-      const totalClaimable = deposited - withdrawn + accrued;
-
-      setLiveClaimable(totalClaimable > deposited ? deposited : totalClaimable);
-    };
-
-    updateClaimable();
-    const interval = setInterval(updateClaimable, 1000);
-
-    return () => clearInterval(interval);
-  }, [stream]);
 
   const isSender = useMemo(() => {
     if (!session || !stream) return false;


### PR DESCRIPTION
## Summary

Closes #1267  — removes the duplicated "live claimable amount" ticking logic on the stream-details page and routes it through the same shared, visibility-aware hook (`useStreamingAmount`) that the dashboard already uses.

**Location:** `frontend/src/app/streams/[id]/stream-details-content.tsx` vs `frontend/src/hooks/useStreamingAmount.ts`

## Problem

The dashboard and the stream-details page computed the identical "ticking claimable amount" concept with two independent implementations:

- **Dashboard** → `useStreamingAmount` (rAF-based, pauses recomputation while the tab is hidden, resyncs on visibility change).
- **Stream details** → a plain `setInterval(…, 1000)` that keeps ticking even when the tab is backgrounded (Performance #40) and uses a less careful formula.

## Changes

- **`frontend/src/app/streams/[id]/stream-details-content.tsx`**
  - Deleted the inline `setInterval` effect and its duplicated `updateClaimable` math.
  - Replaced it with a call to the shared `useStreamingAmount` hook, passing the same inputs the dashboard passes (`deposited`, `withdrawn`, `ratePerSecond`, `lastUpdateTime`, `isActive`, `isPaused`, `pausedAt`).
  - The hook returns a `number` (same as the dashboard), while this page formats raw stroop amounts, so the value is rounded back to an exact `bigint` (`BigInt(Math.round(...))`) for display via `formatAmount` and for the Withdraw-button enabled check. `liveClaimable` keeps its existing `bigint` type, so the render path is unchanged.
- **`frontend/src/app/streams/[id]/__tests__/stream-details-content.test.tsx`**
  - Added a test verifying the "Claimable" stat card renders the value produced by the shared hook (the hook's own math is covered by `frontend/src/__tests__/useStreamingAmount.test.tsx`).

## Why the hook's math is the correct one

The hook's model matches the backend source of truth (`backend/src/services/claimable.service.ts`) and the documented formula in `docs/ARCHITECTURE.md`:

```
effectiveElapsed = max(0, now - lastUpdateTime - currentPauseDuration)
claimable = min(effectiveElapsed * ratePerSecond, deposited - withdrawn)
```

The removed inline implementation instead computed `min(deposited, deposited - withdrawn + accrued)` without accounting for the current pause interval — overstating the claimable amount after withdrawals and while paused. Replacing it also fixes the visibility-awareness gap (Performance #40): rAF ticking halts while the tab is hidden and resyncs from true elapsed time when it becomes visible again.

## Acceptance criteria

- [x] Both the dashboard and the stream-details page compute claimable amounts through the same shared hook (`useStreamingAmount`).

## Testing

- `npx vitest run` (frontend): **32 test files, 287 tests passed** — including the new wiring test and the existing `useStreamingAmount` suite.
- `npx eslint` on the changed files: clean.
- `npx tsc --noEmit`: no new errors (only pre-existing errors in untouched test files).

## Notes

- Precision: like the dashboard, the hook operates on JS `number`s. Amounts within `Number.MAX_SAFE_INTEGER` (≈9e15 stroops ≈ 9M tokens) round-trip exactly through `BigInt(Math.round(...))`, and non-finite inputs are guarded to display `0`.