### PR TITLE
fix: report indexer lag in checks.indexer.status breakdown (#1236)

### DIFF
--- a/backend/src/routes/health.routes.ts
+++ b/backend/src/routes/health.routes.ts
@@ -163,7 +163,7 @@ router.get('/', async (_req: Request, res: Response) => {
         status: dbStatus === 'connected' ? 'ok' : 'down',
       },
       indexer: {
-        status: !indexerEnabled ? 'disabled' : indexerFailureDegraded ? 'degraded' : 'ok',
+        status: !indexerEnabled ? 'disabled' : indexerFailureDegraded || indexerLagDegraded ? 'degraded' : 'ok',
         enabled: indexerEnabled,
         lagSeconds: indexerLag === -1 ? null : indexerLag,
       },

--- a/backend/tests/health.test.ts
+++ b/backend/tests/health.test.ts
@@ -62,6 +62,7 @@ describe('GET /health', () => {
     expect(res.body.status).toBe('ok');
     expect(res.body.db).toBe('connected');
     expect(res.body.indexerEnabled).toBe(false);
+    expect(res.body.checks.indexer.status).toBe('disabled');
     expect(res.body.indexerLag).toBeNull();
     expect(res.body.eventsProcessed).toBe(0);
     expect(res.body.eventsFailed).toBe(0);
@@ -78,6 +79,7 @@ describe('GET /health', () => {
     expect(res.body.status).toBe('ok');
     expect(res.body.indexerEnabled).toBe(true);
     expect(res.body.indexerLag).toBeNull();
+    expect(res.body.checks.indexer.status).toBe('ok');
   });
 
   it('returns 200 when DB is up, indexer enabled, and lag is within threshold', async () => {
@@ -89,6 +91,7 @@ describe('GET /health', () => {
     expect(res.body.status).toBe('ok');
     expect(res.body.indexerLag).toBeGreaterThanOrEqual(0);
     expect(res.body.indexerLag).toBeLessThanOrEqual(60);
+    expect(res.body.checks.indexer.status).toBe('ok');
   });
 
   it('returns 503 when DB is up, indexer enabled, and lag exceeds 60 s', async () => {
@@ -99,6 +102,7 @@ describe('GET /health', () => {
     expect(res.status).toBe(503);
     expect(res.body.status).toBe('degraded');
     expect(res.body.indexerLag).toBeGreaterThan(60);
+    expect(res.body.checks.indexer.status).toBe('degraded');
   });
 
   it('returns 503 when DB is down regardless of indexer state', async () => {
@@ -139,5 +143,6 @@ describe('GET /health', () => {
     expect(res.body.eventsFailed).toBe(10);
     expect(res.body.lastErrorAt).toBe('2026-07-27T08:00:00.000Z');
     expect(res.body.indexerDegraded).toBe(true);
+    expect(res.body.checks.indexer.status).toBe('degraded');
   });
 });


### PR DESCRIPTION
Closes #1236

## Problem

The health endpoint's granular breakdown could contradict its own top-level verdict. `checks.indexer.status` was computed as:

```
!indexerEnabled ? 'disabled' : indexerFailureDegraded ? 'degraded' : 'ok'
```

`indexerLagDegraded` (enabled + lag > 60 s) drives the top-level `status`/HTTP 503, but was never included in the per-subsystem ternary. During a lag-only incident, the endpoint returned `status: "degraded"` / HTTP 503 while `checks.indexer.status` simultaneously reported `"ok"` — an actively misleading signal in the exact breakdown meant to diagnose the incident.

## Fix

Include `indexerLagDegraded` in the same condition used for the top-level verdict, so the breakdown always matches:

```
!indexerEnabled ? 'disabled' : indexerFailureDegraded || indexerLagDegraded ? 'degraded' : 'ok'
```

## Tests

Extended `backend/tests/health.test.ts` with `checks.indexer.status` assertions across all indexer states:

- **Lag-only degradation** (enabled, lag 120 s, no failure spike) → `checks.indexer.status === 'degraded'`, matching the top-level `status: "degraded"` and HTTP 503 (the acceptance-criteria case)
- Event-failure spike degradation → `'degraded'`
- Healthy within-threshold lag → `'ok'`
- Enabled cold start (no state row) → `'ok'`
- Indexer disabled → `'disabled'`

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 386 passed, 16 skipped (integration tests requiring a live DB)