### PR TITLE
perf: aggregate admin metrics in SQL instead of app memory (fixes #1245)

### DIFF
--- a/backend/src/routes/v1/admin.routes.ts
+++ b/backend/src/routes/v1/admin.routes.ts
@@ -47,9 +47,9 @@ async function buildAdminMetrics() {
     completedCount,
     eventsLast24h,
     indexerState,
-    feeEvents,
-    feesLast24h,
-    withdrawnSums,
+    feeRows,
+    feesLast24hRows,
+    withdrawnVolume,
   ] = await Promise.all([
     prisma.stream.count({ where: { isActive: true } }),
     prisma.stream.count({ where: { isPaused: true } }),
@@ -62,44 +62,48 @@ async function buildAdminMetrics() {
     }),
     prisma.streamEvent.count({ where: { createdAt: { gte: since24h } } }),
     prisma.indexerState.findUnique({ where: { id: INDEXER_STATE_ID } }),
-    prisma.streamEvent.findMany({
-      where: { eventType: 'FEE_COLLECTED' },
-      select: { amount: true, metadata: true },
-    }),
-    prisma.streamEvent.findMany({
-      where: { eventType: 'FEE_COLLECTED', createdAt: { gte: since24h } },
-      select: { amount: true, metadata: true },
-    }),
-    prisma.stream.findMany({ select: { withdrawnAmount: true } }),
+    // Fee totals are aggregated in Postgres (GROUP BY token) instead of
+    // shipping every FEE_COLLECTED row to Node and summing in a JS loop.
+    // Keeps the endpoint a constant number of round-trips regardless of how
+    // many historical events exist (issue #1245).
+    prisma.$queryRaw<Array<{ token: string; total: string }>>`
+      SELECT
+        COALESCE(NULLIF(metadata::json ->> 'token', ''), 'unknown') AS token,
+        SUM(CAST(amount AS numeric))::text AS total
+      FROM "StreamEvent"
+      WHERE "eventType" = 'FEE_COLLECTED'
+      GROUP BY 1
+    `,
+    prisma.$queryRaw<Array<{ token: string; total: string }>>`
+      SELECT
+        COALESCE(NULLIF(metadata::json ->> 'token', ''), 'unknown') AS token,
+        SUM(CAST(amount AS numeric))::text AS total
+      FROM "StreamEvent"
+      WHERE "eventType" = 'FEE_COLLECTED' AND "createdAt" >= ${since24h}
+      GROUP BY 1
+    `,
+    // Total volume streamed is summed in Postgres via numeric (arbitrary
+    // precision) to preserve i128 values exactly, instead of pulling every
+    // stream row into Node (issue #1245).
+    prisma.$queryRaw<Array<{ total: string }>>`
+      SELECT COALESCE(SUM(CAST("withdrawnAmount" AS numeric)), 0)::text AS total
+      FROM "Stream"
+    `,
   ]);
 
-  // Aggregate fees by token
+  // Aggregate fees by token (SQL already grouped these; just map rows to keys)
   const totalFeesCollectedByToken: Record<string, string> = {};
+  for (const row of feeRows) {
+    totalFeesCollectedByToken[row.token] = row.total;
+  }
+
   const feesLast24hByToken: Record<string, string> = {};
-
-  for (const event of feeEvents) {
-    const metadata = event.metadata ? JSON.parse(event.metadata) : {};
-    const token = metadata.token || 'unknown';
-    const amount = BigInt(event.amount || '0');
-    totalFeesCollectedByToken[token] = (
-      BigInt(totalFeesCollectedByToken[token] || '0') + amount
-    ).toString();
+  for (const row of feesLast24hRows) {
+    feesLast24hByToken[row.token] = row.total;
   }
 
-  for (const event of feesLast24h) {
-    const metadata = event.metadata ? JSON.parse(event.metadata) : {};
-    const token = metadata.token || 'unknown';
-    const amount = BigInt(event.amount || '0');
-    feesLast24hByToken[token] = (
-      BigInt(feesLast24hByToken[token] || '0') + amount
-    ).toString();
-  }
-
-  // Sum total volume streamed (sum of withdrawn amounts) as BigInt to preserve i128 precision.
-  let totalVolumeStreamed = BigInt(0);
-  for (const row of withdrawnSums) {
-    totalVolumeStreamed += BigInt(row.withdrawnAmount || '0');
-  }
+  // Total volume streamed (sum of withdrawn amounts) as a string to preserve i128 precision.
+  const totalVolumeStreamed = withdrawnVolume[0]?.total ?? '0';
 
   const nowSec = Math.floor(Date.now() / 1000);
   const lagSeconds = indexerState

--- a/backend/tests/integration/admin-metrics.test.ts
+++ b/backend/tests/integration/admin-metrics.test.ts
@@ -49,6 +49,7 @@ const mocks = vi.hoisted(() => {
       indexerState: {
         findUnique: vi.fn(),
       },
+      $queryRaw: vi.fn(),
       $disconnect: vi.fn(),
     },
     pool: {
@@ -184,18 +185,22 @@ describe('GET /v1/admin/metrics', () => {
     process.env.ADMIN_PUBLIC_KEY = ADMIN_PUBLIC_KEY;
     mocks.cache.get.mockReturnValue(null);
     mocks.prisma.streamEvent.count.mockResolvedValue(0);
-    mocks.prisma.streamEvent.findMany.mockResolvedValue([]);
     mocks.prisma.indexerState.findUnique.mockResolvedValue(null);
-    mocks.prisma.stream.findMany.mockResolvedValue([]);
+    // The three aggregations (fees all-time, fees last 24h, withdrawn volume)
+    // run as raw SQL aggregates; default to empty results so tests that don't
+    // care about them see zeroed metrics.
+    mocks.prisma.$queryRaw.mockResolvedValue([]);
   });
 
   it('returns the snake_case summary required by the public contract', async () => {
     setupCounts({ total: 12, active: 7, paused: 2, cancelled: 2, completed: 1 });
-    mocks.prisma.stream.findMany.mockResolvedValue([
-      { withdrawnAmount: '500' },
-      { withdrawnAmount: '1500' },
-      { withdrawnAmount: '0' },
-    ]);
+    mocks.prisma.$queryRaw
+      .mockResolvedValueOnce([
+        { token: 'XLM', total: '300' },
+        { token: 'USDC', total: '450' },
+      ])
+      .mockResolvedValueOnce([{ token: 'XLM', total: '120' }])
+      .mockResolvedValueOnce([{ total: '2000' }]);
 
     const res = await request(app)
       .get('/v1/admin/metrics')
@@ -215,11 +220,11 @@ describe('GET /v1/admin/metrics', () => {
   it('preserves precision for very large i128 withdrawn sums', async () => {
     setupCounts();
     // Two values whose sum overflows JS safe-integer range — must round-trip
-    // as the exact string.
-    mocks.prisma.stream.findMany.mockResolvedValue([
-      { withdrawnAmount: '9007199254740993' },
-      { withdrawnAmount: '9007199254740993' },
-    ]);
+    // as the exact string (summed in Postgres via numeric).
+    mocks.prisma.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ total: '18014398509481986' }]);
 
     const res = await request(app)
       .get('/v1/admin/metrics')
@@ -227,6 +232,51 @@ describe('GET /v1/admin/metrics', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.total_volume_streamed).toBe('18014398509481986');
+  });
+
+  it('aggregates fees by token from SQL GROUP BY results (all-time and last 24h)', async () => {
+    setupCounts();
+    mocks.prisma.$queryRaw
+      .mockResolvedValueOnce([
+        { token: 'XLM', total: '1000000000' },
+        { token: 'USDC', total: '250000000' },
+        { token: 'unknown', total: '5' },
+      ])
+      .mockResolvedValueOnce([{ token: 'XLM', total: '75000000' }])
+      .mockResolvedValueOnce([{ total: '0' }]);
+
+    const res = await request(app)
+      .get('/v1/admin/metrics')
+      .set('Authorization', `Bearer ${createToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.fees).toEqual({
+      totalFeesCollectedByToken: {
+        XLM: '1000000000',
+        USDC: '250000000',
+        unknown: '5',
+      },
+      feesLast24h: { XLM: '75000000' },
+    });
+  });
+
+  it('computes volume/fee metrics via a constant number of aggregate queries (no row-by-row fetching)', async () => {
+    setupCounts();
+    mocks.prisma.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ total: '42' }]);
+
+    const res = await request(app)
+      .get('/v1/admin/metrics')
+      .set('Authorization', `Bearer ${createToken()}`);
+
+    expect(res.status).toBe(200);
+    // Exactly three aggregate queries (fees all-time, fees last 24h, volume)
+    // regardless of how many rows exist — sub-linear, constant round-trips.
+    expect(mocks.prisma.$queryRaw).toHaveBeenCalledTimes(3);
+    expect(mocks.prisma.stream.findMany).not.toHaveBeenCalled();
+    expect(mocks.prisma.streamEvent.findMany).not.toHaveBeenCalled();
   });
 
   it('caches the response for 60 seconds', async () => {
@@ -274,7 +324,7 @@ describe('GET /v1/admin/metrics', () => {
     expect(res.headers['x-cache']).toBe('HIT');
     expect(res.body).toMatchObject(cachedPayload);
     expect(mocks.prisma.stream.count).not.toHaveBeenCalled();
-    expect(mocks.prisma.stream.findMany).not.toHaveBeenCalled();
+    expect(mocks.prisma.$queryRaw).not.toHaveBeenCalled();
   });
 
   it('exposes indexer event-processing counters and degraded signal (#844)', async () => {


### PR DESCRIPTION
## Summary

Closes #1245  — the `GET /v1/admin/metrics` endpoint no longer pulls entire tables into Node to sum them in JS loops. Fee totals (all-time and last 24h) and total withdrawn volume are now aggregated inside Postgres with a single SQL query each.

**Location:** `backend/src/routes/v1/admin.routes.ts:65-102` (`buildAdminMetrics`)

## Problem

Three metrics were computed with `findMany` + manual JS summation:

- `feeEvents` — `prisma.streamEvent.findMany({ where: { eventType: 'FEE_COLLECTED' } })` → loop summing `amount` by token.
- `feesLast24h` — same, filtered to the last 24h.
- `withdrawnSums` — `prisma.stream.findMany({ select: { withdrawnAmount: true } })` (no filter, no limit) → loop summing every stream's withdrawn amount.

These scale linearly (unboundedly) with total historical event/stream count, transferring every matching row from Postgres to Node on every cache-miss.

## Changes

**`backend/src/routes/v1/admin.routes.ts`** — replaced all three `findMany` calls with raw SQL aggregates:

- Fee totals by token (all-time and last 24h) — one `GROUP BY` per window:
  ```sql
  SELECT
    COALESCE(NULLIF(metadata::json ->> 'token', ''), 'unknown') AS token,
    SUM(CAST(amount AS numeric))::text AS total
  FROM "StreamEvent"
  WHERE "eventType" = 'FEE_COLLECTED' [AND "createdAt" >= $1]
  GROUP BY 1
  ```
  - `metadata` is a JSON **string** column, so the token is extracted with `metadata::json ->> 'token'` (FEE_COLLECTED events store `{ treasury, token }` — verified in `soroban-event-worker.ts`).
  - `COALESCE(NULLIF(..., ''), 'unknown')` reproduces the old `metadata.token || 'unknown'` fallback exactly.
- Total volume streamed — one `SUM`:
  ```sql
  SELECT COALESCE(SUM(CAST("withdrawnAmount" AS numeric)), 0)::text AS total FROM "Stream"
  ```
  - `withdrawnAmount` is stored as a **string** (i128 precision), so `numeric` (arbitrary precision) is used instead of a lossy JS number — sums beyond `Number.MAX_SAFE_INTEGER` round-trip exactly.
- `Prisma.aggregate({ _sum })` was considered, but Prisma does not support `_sum` on `String` columns (both `amount` and `withdrawnAmount` are strings), so `$queryRaw` is the correct tool here.

**`backend/tests/integration/admin-metrics.test.ts`**
- Mocked `prisma.$queryRaw` (the metrics aggregations now run as raw queries).
- Kept the snake_case contract test and the i128-precision test (exact string round-trip for sums beyond JS safe-integer range).
- Added: fee aggregation by token (all-time + last 24h) coverage.
- Added: a test asserting the metrics request performs **exactly three aggregate queries** and never calls `findMany` on `stream`/`streamEvent` — executable evidence of the constant (sub-linear) round-trip behavior.

## Acceptance criteria

- [x] The same metrics are produced via `_sum`/raw aggregate queries.
- [x] Sub-linear (constant round-trip) behavior as table size grows — the endpoint now issues a fixed set of aggregate queries (1 per metric, using the existing `eventType` / `createdAt` indexes) regardless of row count; the added test locks in the constant query count.

## Testing

- `npx vitest run` (backend): **51 test files, 388 passed, 16 skipped** — no failures.
- `npx tsc --noEmit` (backend): clean.
- The full-suite coverage-threshold failure is pre-existing repo config (global 60% threshold; suite-wide coverage is below that on `main` too); this change only adds tests.

## Notes

- No benchmark harness exists in the repo, so the "benchmark" criterion is satisfied with the constant-round-trip test above plus the query-plan-friendly shape (single `SUM`/`GROUP BY` over indexed columns).
- Response shape is unchanged: `total_volume_streamed` and `fees.totalFeesCollectedByToken` / `fees.feesLast24h` keep their exact string values.