### PR TITLE
refactor(dashboard): use cached useDashboard hook for snapshot data

### DIFF
--- a/frontend/src/components/dashboard/dashboard-view.test.tsx
+++ b/frontend/src/components/dashboard/dashboard-view.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+//
+// dashboard-view.tsx pulls in a lot of feature components (the stream
+// creation wizard, modals, SSE status indicator, etc.) that aren't relevant
+// to the "does switching tabs/routes re-trigger a network fetch within
+// staleTime" question this file is about. They're stubbed out below so the
+// test can focus on the useDashboard/query-cache wiring.
+
+vi.mock("@/hooks/useStreamEvents", () => ({
+  useStreamEvents: () => ({
+    events: [],
+    connected: true,
+    reconnecting: false,
+    error: null,
+  }),
+}));
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+    loading: vi.fn(() => "toast-id"),
+  },
+}));
+
+vi.mock("@/lib/soroban", () => ({
+  createStream: vi.fn(),
+  topUpStream: vi.fn(),
+  cancelStream: vi.fn(),
+  withdrawFromStream: vi.fn(),
+  toBaseUnits: vi.fn((v: string) => BigInt(v)),
+  toDurationSeconds: vi.fn(() => 0),
+  getTokenAddress: vi.fn((symbol: string) => symbol),
+  toSorobanErrorMessage: vi.fn((e) => String(e)),
+}));
+
+vi.mock("@/lib/stellar", () => ({
+  isValidStellarPublicKey: vi.fn(() => true),
+}));
+
+vi.mock("../IncomingStreams", () => ({
+  default: () => <div data-testid="incoming-streams" />,
+}));
+
+vi.mock("./SSEStatusIndicator", () => ({
+  SSEStatusIndicator: () => <div data-testid="sse-status" />,
+}));
+
+vi.mock("../stream-creation/StreamCreationWizard", () => ({
+  StreamCreationWizard: () => <div data-testid="stream-wizard" />,
+}));
+
+vi.mock("../stream-creation/TopUpModal", () => ({
+  TopUpModal: () => <div data-testid="topup-modal" />,
+}));
+
+vi.mock("../stream-creation/CancelConfirmModal", () => ({
+  CancelConfirmModal: () => <div data-testid="cancel-modal" />,
+}));
+
+vi.mock("./StreamDetailsModal", () => ({
+  StreamDetailsModal: () => <div data-testid="details-modal" />,
+}));
+
+vi.mock("../ui/Button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    ...rest
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    glow?: boolean;
+    variant?: string;
+    size?: string;
+    children?: React.ReactNode;
+  }) => (
+    <button onClick={onClick} disabled={disabled} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+import { DashboardView } from "./dashboard-view";
+import type { WalletSession } from "@/lib/wallet";
+
+const PUBLIC_KEY = "GABCDEFPUBLICKEY000000000000000000000000000000000000000";
+
+const session: WalletSession = {
+  walletId: "freighter",
+  walletName: "Freighter",
+  publicKey: PUBLIC_KEY,
+  connectedAt: new Date().toISOString(),
+  network: "TESTNET",
+  mocked: false,
+};
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response;
+}
+
+describe("DashboardView + useDashboard cache integration", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse([])));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not issue a duplicate network fetch when the dashboard is unmounted and remounted within staleTime (e.g. switching tabs away and back)", async () => {
+    // Mirror the app's real QueryClient defaults (see
+    // frontend/src/components/providers/query-provider.tsx) so this proves
+    // the behavior users actually get: staleTime 10s means a remount within
+    // that window should be served from cache, not refetched.
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { staleTime: 10_000, refetchOnWindowFocus: false, retry: 1 },
+      },
+    });
+
+    const renderDashboard = () =>
+      render(
+        <QueryClientProvider client={queryClient}>
+          <DashboardView session={session} onDisconnect={vi.fn()} />
+        </QueryClientProvider>,
+      );
+
+    const first = renderDashboard();
+    await waitFor(() =>
+      expect(screen.getByText(/start your first stream/i)).toBeInTheDocument(),
+    );
+    // One request each for outgoing ("sender") and incoming ("recipient") streams.
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    // Simulate navigating/switching away from the dashboard and back within
+    // the 10s staleTime window.
+    first.unmount();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <DashboardView session={session} onDisconnect={vi.fn()} />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/start your first stream/i)).toBeInTheDocument(),
+    );
+
+    // Still just the 2 calls from the first mount — the remounted dashboard
+    // was served from the React Query cache instead of refetching.
+    expect(fetch).toHaveBeenCalledTimes(2);
+  }, 20000);
+
+  it("shows the loading skeleton, then renders content once useDashboard resolves", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <DashboardView session={session} onDisconnect={vi.fn()} />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByLabelText(/loading dashboard/i)).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByText(/start your first stream/i)).toBeInTheDocument(),
+    );
+  }, 20000);
+
+  it("shows the error state with a retry button when the fetch fails, and retrying refetches", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("network down")),
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <DashboardView session={session} onDisconnect={vi.fn()} />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load streams/i)).toBeInTheDocument(),
+    );
+
+    const callsBeforeRetry = vi.mocked(fetch).mock.calls.length;
+
+    vi.mocked(fetch).mockResolvedValue(jsonResponse([]));
+    screen.getByRole("button", { name: /retry/i }).click();
+
+    await waitFor(() =>
+      expect(screen.getByText(/start your first stream/i)).toBeInTheDocument(),
+    );
+
+    expect(vi.mocked(fetch).mock.calls.length).toBeGreaterThan(
+      callsBeforeRetry,
+    );
+  }, 20000);
+});

--- a/frontend/src/components/dashboard/dashboard-view.tsx
+++ b/frontend/src/components/dashboard/dashboard-view.tsx
@@ -17,7 +17,7 @@ import toast from "react-hot-toast";
 
 import {
   getDashboardAnalytics,
-  fetchDashboardData,
+  useDashboard,
   dashboardQueryKey,
   type DashboardSnapshot,
   type Stream,
@@ -511,11 +511,20 @@ export function DashboardView({ session, onDisconnect }: DashboardViewProps) {
   const [showWizard, setShowWizard] = React.useState(false);
   const [modal, setModal] = React.useState<ModalState>(null);
 
-  const [snapshot, setSnapshot] = React.useState<DashboardSnapshot | null>(
-    null,
-  );
-  const [isSnapshotLoading, setIsSnapshotLoading] = React.useState(true);
-  const [snapshotError, setSnapshotError] = React.useState<string | null>(null);
+  const {
+    data: snapshotData,
+    isLoading: isSnapshotLoading,
+    isError: isSnapshotError,
+    error: snapshotErrorObj,
+    refetch: refetchSnapshot,
+  } = useDashboard(session.publicKey);
+
+  const snapshot: DashboardSnapshot | null = snapshotData ?? null;
+  const snapshotError = isSnapshotError
+    ? snapshotErrorObj instanceof Error
+      ? snapshotErrorObj.message
+      : "Failed to fetch dashboard data."
+    : null;
 
   const {
     events: streamEvents,
@@ -541,15 +550,9 @@ export function DashboardView({ session, onDisconnect }: DashboardViewProps) {
           "resumed",
         ];
         if (relevantTypes.includes(latestEvent.type)) {
-          fetchDashboardData(session.publicKey)
-            .then(setSnapshot)
-            .catch((err) => {
-              setSnapshotError(
-                err instanceof Error
-                  ? err.message
-                  : "Failed to refresh dashboard",
-              );
-            });
+          void queryClient.invalidateQueries({
+            queryKey: dashboardQueryKey(session.publicKey),
+          });
         }
       }
     }
@@ -618,51 +621,6 @@ export function DashboardView({ session, onDisconnect }: DashboardViewProps) {
     if (!templatesHydrated) return;
     persistTemplates(templates);
   }, [templates, templatesHydrated]);
-
-  // ── Load dashboard snapshot ───────────────────────────────────────────────
-
-  const loadSnapshot = React.useCallback(async () => {
-    setIsSnapshotLoading(true);
-    setSnapshotError(null);
-    try {
-      const next = await fetchDashboardData(session.publicKey);
-      setSnapshot(next);
-    } catch (err) {
-      setSnapshot(null);
-      setSnapshotError(
-        err instanceof Error ? err.message : "Failed to fetch dashboard data.",
-      );
-    } finally {
-      setIsSnapshotLoading(false);
-    }
-  }, [session.publicKey, setIsSnapshotLoading, setSnapshotError, setSnapshot]);
-
-  React.useEffect(() => {
-    let cancelled = false;
-    const run = async () => {
-      setIsSnapshotLoading(true);
-      setSnapshotError(null);
-      try {
-        const next = await fetchDashboardData(session.publicKey);
-        if (!cancelled) setSnapshot(next);
-      } catch (err) {
-        if (!cancelled) {
-          setSnapshot(null);
-          setSnapshotError(
-            err instanceof Error
-              ? err.message
-              : "Failed to fetch dashboard data.",
-          );
-        }
-      } finally {
-        if (!cancelled) setIsSnapshotLoading(false);
-      }
-    };
-    void run();
-    return () => {
-      cancelled = true;
-    };
-  }, [session.publicKey]);
 
   // ── Template handlers ─────────────────────────────────────────────────────
 
@@ -779,15 +737,18 @@ export function DashboardView({ session, onDisconnect }: DashboardViewProps) {
   };
 
   const topUpStreamLocally = (streamId: string, amount: number) => {
-    setSnapshot((prev) => {
-      if (!prev) return prev;
-      return {
-        ...prev,
-        outgoingStreams: prev.outgoingStreams.map((s) =>
-          s.id === streamId ? { ...s, deposited: s.deposited + amount } : s,
-        ),
-      };
-    });
+    queryClient.setQueryData<DashboardSnapshot | undefined>(
+      dashboardQueryKey(session.publicKey),
+      (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          outgoingStreams: prev.outgoingStreams.map((s) =>
+            s.id === streamId ? { ...s, deposited: s.deposited + amount } : s,
+          ),
+        };
+      },
+    );
   };
 
   const addStreamLocally = (data: StreamFormData) => {
@@ -804,14 +765,17 @@ export function DashboardView({ session, onDisconnect }: DashboardViewProps) {
       lastUpdateTime: Math.floor(Date.now() / 1000),
       isActive: true,
     };
-    setSnapshot((prev) => {
-      if (!prev) return prev;
-      return {
-        ...prev,
-        outgoingStreams: [newStream, ...prev.outgoingStreams],
-        activeStreamsCount: prev.activeStreamsCount + 1,
-      };
-    });
+    queryClient.setQueryData<DashboardSnapshot | undefined>(
+      dashboardQueryKey(session.publicKey),
+      (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          outgoingStreams: [newStream, ...prev.outgoingStreams],
+          activeStreamsCount: prev.activeStreamsCount + 1,
+        };
+      },
+    );
   };
 
   // ── Contract handlers ─────────────────────────────────────────────────────
@@ -872,8 +836,7 @@ export function DashboardView({ session, onDisconnect }: DashboardViewProps) {
       await sorobanWithdraw(session, {
         streamId: BigInt(stream.id.replace(/\D/g, "") || "0"),
       });
-      const refreshed = await fetchDashboardData(session.publicKey);
-      setSnapshot(refreshed);
+      await refetchSnapshot();
       toast.success("Withdrawal successful!", { id: toastId });
     } catch (err) {
       toast.error(toSorobanErrorMessage(err), { id: toastId });
@@ -958,7 +921,12 @@ export function DashboardView({ session, onDisconnect }: DashboardViewProps) {
 
     // ── Error state ───────────────────────────────────────────────────────
     if (snapshotError) {
-      return <ErrorState message={snapshotError} onRetry={loadSnapshot} />;
+      return (
+        <ErrorState
+          message={snapshotError}
+          onRetry={() => void refetchSnapshot()}
+        />
+      );
     }
 
     // ── First-time / completely empty wallet ──────────────────────────────

--- a/frontend/src/lib/dashboard.test.ts
+++ b/frontend/src/lib/dashboard.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
 import {
   mapBackendStreamToFrontend,
   getDashboardAnalytics,
   dashboardQueryKey,
+  useDashboard,
   type DashboardSnapshot,
 } from "./dashboard";
 import type { BackendStream } from "./api-types";
@@ -179,5 +183,105 @@ describe("getDashboardAnalytics", () => {
     const metrics = getDashboardAnalytics(snapshot);
     const volume30d = metrics.find((m) => m.id === "total-volume-30d")!;
     expect(volume30d.value).toBe(50); // only the recent activity
+  });
+});
+
+// ── useDashboard ─────────────────────────────────────────────────────────────
+
+describe("useDashboard", () => {
+  const PUBLIC_KEY = "GABCDEFPUBLICKEY000000000000000000000000000000000000000";
+
+  function jsonResponse(body: unknown) {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => body,
+    } as Response;
+  }
+
+  function makeWrapper(queryClient: QueryClient) {
+    return function Wrapper({ children }: { children: React.ReactNode }) {
+      return React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        children,
+      );
+    };
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not fetch when publicKey is empty (disabled query)", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { result } = renderHook(() => useDashboard(""), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches and returns a mapped dashboard snapshot for a given publicKey", async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse([]));
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const { result } = renderHook(() => useDashboard(PUBLIC_KEY), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual<DashboardSnapshot>({
+      totalSent: 0,
+      totalReceived: 0,
+      totalValueLocked: 0,
+      activeStreamsCount: 0,
+      recentActivity: [],
+      outgoingStreams: [],
+      incomingStreams: [],
+    });
+    // one request for outgoing ("sender") streams, one for incoming ("recipient")
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not refetch within staleTime when remounted with the same QueryClient (no duplicate fetch on tab switch)", async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse([]));
+    // Mirror the app's real QueryClient defaults (frontend/src/components/providers/query-provider.tsx)
+    // so this test proves the behavior users actually get.
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { staleTime: 10_000, refetchOnWindowFocus: false, retry: 1 },
+      },
+    });
+    const wrapper = makeWrapper(queryClient);
+
+    const first = renderHook(() => useDashboard(PUBLIC_KEY), { wrapper });
+    await waitFor(() => expect(first.result.current.isSuccess).toBe(true));
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    // Simulate navigating away (unmount) and back (remount) within the
+    // 10s staleTime window, sharing the same QueryClient instance the way
+    // the app's QueryProvider keeps one alive across route/tab changes.
+    first.unmount();
+
+    const second = renderHook(() => useDashboard(PUBLIC_KEY), { wrapper });
+    await waitFor(() =>
+      expect(second.result.current.data).toBeDefined(),
+    );
+
+    // Cache hit: still just the 2 calls from the initial mount — no
+    // duplicate network fetch for switching away and back within staleTime.
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(second.result.current.isFetching).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #1244

## What changed

`useDashboard` (`frontend/src/lib/dashboard.ts`) is a React Query hook — it inherits `staleTime: 10_000`, `refetchOnWindowFocus: false`, and `retry: 1` from the `QueryClient` created in `frontend/src/components/providers/query-provider.tsx` — but it was exported and never called anywhere. `DashboardView` instead hand-rolled its own `useState`/`useEffect` fetch of the snapshot, so every mount refetched from scratch with no caching, retry, or request dedup, and switching tabs/routes away and back re-fetched the same data unnecessarily.

`DashboardView` now calls `useDashboard(session.publicKey)` and drives all snapshot state through the React Query cache:

- **Loading/error state** now come from the hook's `isLoading` / `isError` / `error` instead of separate `useState` flags.
- **Optimistic local updates** (`topUpStreamLocally`, `addStreamLocally`) now write through `queryClient.setQueryData(dashboardQueryKey(session.publicKey), updaterFn)` instead of a local `setSnapshot`, so the cache and the UI stay in sync.
- **SSE-triggered refresh**: when a relevant stream event arrives over SSE, the component now calls `queryClient.invalidateQueries({ queryKey: dashboardQueryKey(session.publicKey) })` instead of manually calling `fetchDashboardData` and `setSnapshot`. React Query handles the refetch and re-render.
- **Withdraw flow**: after a successful withdrawal, the component calls the hook's `refetchSnapshot()` (React Query's `refetch`) instead of manually re-fetching and calling `setSnapshot`.
- **Error retry button** calls `refetchSnapshot()` instead of a bespoke `loadSnapshot` callback.
- The old hand-rolled `useEffect` fetch-on-mount effect and `loadSnapshot` callback were removed entirely — `useDashboard` now owns the fetch/cache lifecycle.

Because the hook's `queryFn` (`fetchDashboardData`) and `queryKey` (`dashboardQueryKey(publicKey)`) are unchanged, and the app's root layout already wraps everything in the single long-lived `QueryProvider`/`QueryClient`, remounting `DashboardView` (e.g. navigating away and back, or switching tabs) within the 10s `staleTime` window is now served from cache instead of issuing a new network request.

## Files changed

**Modified**
- `frontend/src/components/dashboard/dashboard-view.tsx` — replaced hand-rolled fetch/loading/error state with `useDashboard`; optimistic updates and SSE refresh now go through the query cache; withdraw/retry use `refetchSnapshot`.
- `frontend/src/lib/dashboard.test.ts` — added a `describe("useDashboard", ...)` block.

**New**
- `frontend/src/components/dashboard/dashboard-view.test.tsx` — component-level tests for `DashboardView` wired to a real `QueryClient`.

## Tests added

In `frontend/src/lib/dashboard.test.ts` (`useDashboard` hook, via `renderHook` + `QueryClientProvider`):
- Query is disabled (no fetch) when `publicKey` is empty.
- Fetches and maps outgoing/incoming streams into a `DashboardSnapshot` (2 backend requests: sender + recipient).
- **Acceptance criterion**: with a `QueryClient` configured with the app's real defaults (`staleTime: 10_000`, `refetchOnWindowFocus: false`, `retry: 1`), unmounting and remounting `useDashboard` with the same `QueryClient` within the staleTime window results in **no additional fetch calls** — the second mount is served from cache (`fetchStatus`/`isFetching` confirm no in-flight refetch).

In `frontend/src/components/dashboard/dashboard-view.test.tsx` (full `DashboardView`, with `useStreamEvents`, `react-hot-toast`, `@/lib/soroban`, `@/lib/stellar`, and heavy child components — wizard/modals/SSE indicator/`IncomingStreams` — mocked out so the test focuses on the query-cache wiring):
- Unmounting and remounting `DashboardView` within the staleTime window does not issue a duplicate network fetch (mirrors the issue's acceptance criterion end-to-end through the real component).
- Shows the loading skeleton, then renders content once `useDashboard` resolves.
- Shows the error state with a retry button when the fetch fails, and clicking retry successfully refetches.

## Manual test plan

1. Run the frontend (`npm run dev --workspace=frontend`) against a backend with some streams for a connected wallet.
2. Open the dashboard, open the browser Network tab, and note the two `/streams` requests (sender + recipient).
3. Switch to another tab/route in the app and back to the dashboard within ~10 seconds. Confirm in the Network tab that **no new `/streams` requests fire** — the dashboard renders instantly from cache.
4. Wait past the 10s `staleTime` window, switch away and back again, and confirm a fresh fetch **does** happen this time.
5. Top up or create a stream — confirm the UI updates immediately via the optimistic `queryClient.setQueryData` write, without a network round trip.
6. Trigger a relevant SSE event (create/top-up/withdraw/cancel/pause/resume from another session) and confirm the dashboard automatically refetches and reflects the change (via `invalidateQueries`).
7. Withdraw from a stream — confirm the dashboard refetches and reflects the updated balance.
8. Force a fetch failure (e.g. stop the backend) — confirm the error state renders with a retry button, and clicking retry re-fetches and recovers once the backend is back.
