### PR TITLE
test(streams): cover double-withdraw fund-accounting edge case

### DIFF
--- a/backend/tests/integration/streams/withdraw.test.ts
+++ b/backend/tests/integration/streams/withdraw.test.ts
@@ -194,4 +194,115 @@ describe('POST /api/v1/streams/:streamId/withdraw', () => {
     expect(response.status).toBe(409);
     expect(response.body.message).toBe('No claimable balance is currently available');
   });
+
+  it('does not double-count withdrawnAmount when the same claim window is withdrawn twice in a row', async () => {
+    const recipient = makeKeypair();
+    const token = setAuthAs(recipient);
+
+    const streamId = 456;
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    // Stateful in-memory representation of the Stream row. Rather than
+    // stubbing each call with independent, hand-picked withdrawnAmount
+    // values, this object is genuinely mutated by the mocked atomic
+    // increment below (mirroring the real
+    // `UPDATE "Stream" SET "withdrawnAmount" = withdrawnAmount + $1 ...`
+    // SQL), so the second withdraw call's re-fetch actually observes
+    // whatever the first call did.
+    const streamState = {
+      streamId,
+      sender: makeKeypair().publicKey(),
+      recipient: recipient.publicKey(),
+      ratePerSecond: '100',
+      depositedAmount: '10000000',
+      withdrawnAmount: '0',
+      startTime: nowSec - 5000,
+      lastUpdateTime: nowSec - 5000, // 5000s of unclaimed accrual
+      isActive: true,
+      isPaused: false,
+      pausedAt: null,
+      totalPausedDuration: 0,
+      updatedAt: new Date(),
+    };
+
+    // Restore the plain pass-through $transaction implementation: an earlier
+    // test in this file (the "successful withdraw" case) replaces it with a
+    // custom implementation that queues a one-off findUnique() stub, which
+    // vi.clearAllMocks() does not undo (it clears call history, not custom
+    // implementations). Without this reset, that stale stub would leak into
+    // this test's re-fetch.
+    mockPrisma.$transaction.mockImplementation(async (fn: any) => fn(mockPrisma));
+
+    // Both the handler's initial read and the transaction's post-increment
+    // re-read go through this, always reflecting the *current* state.
+    mockPrisma.stream.findUnique.mockImplementation(async () => ({ ...streamState }));
+
+    // Simulates the handler's atomic SQL increment:
+    // UPDATE "Stream" SET "withdrawnAmount" = withdrawnAmount + $1, "lastUpdateTime" = $2
+    mockPrisma.$executeRawUnsafe.mockImplementation(
+      async (_sql: string, withdrawAmountStr: string, lastUpdateTime: bigint) => {
+        streamState.withdrawnAmount = (
+          BigInt(streamState.withdrawnAmount) + BigInt(withdrawAmountStr)
+        ).toString();
+        streamState.lastUpdateTime = Number(lastUpdateTime);
+        return undefined;
+      },
+    );
+
+    mockPrisma.stream.update.mockImplementation(async ({ data }: any) => {
+      Object.assign(streamState, data);
+      return { ...streamState };
+    });
+
+    let sorobanCallCount = 0;
+    mockWithdraw.mockImplementation(async () => {
+      sorobanCallCount += 1;
+      return { txHash: `withdraw-tx-hash-${sorobanCallCount}` };
+    });
+
+    // --- First withdraw: claims the full ~5000s * 100/s accrued window ---
+    const first = await request(app)
+      .post(`/v1/streams/${streamId}/withdraw`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(first.status).toBe(200);
+    const firstClaimed = BigInt(first.body.amount);
+    // Allow a little slack for real wall-clock time elapsed while the test
+    // was setting up / the request was in flight.
+    expect(firstClaimed).toBeGreaterThanOrEqual(499000n);
+    expect(first.body.stream.withdrawnAmount).toBe(firstClaimed.toString());
+
+    // --- Second withdraw, immediately after, for the SAME stream/recipient ---
+    const second = await request(app)
+      .post(`/v1/streams/${streamId}/withdraw`)
+      .set('Authorization', `Bearer ${token}`);
+
+    const totalWithdrawn = BigInt(streamState.withdrawnAmount);
+
+    if (second.status === 200) {
+      // Some real wall-clock time may legitimately have elapsed between the
+      // two requests, so a small additional claim on top of the first is
+      // acceptable — but it must be nowhere near a second full claim of the
+      // already-withdrawn window (which would indicate double-counting).
+      const secondClaimed = BigInt(second.body.amount);
+      expect(secondClaimed).toBeLessThan(firstClaimed / 10n);
+    } else {
+      // No meaningful time has elapsed since the first withdraw bumped
+      // lastUpdateTime, so the second call correctly finds nothing left to
+      // claim in this window and is rejected.
+      expect(second.status).toBe(409);
+      expect(second.body.message).toBe('No claimable balance is currently available');
+    }
+
+    // The critical assertion: withdrawnAmount reflects only the ONE
+    // legitimate claim of the accrued window (plus, at most, a negligible
+    // sliver of genuinely new accrual) — never a second full claim of the
+    // same already-withdrawn window.
+    expect(totalWithdrawn).toBeGreaterThanOrEqual(firstClaimed);
+    expect(totalWithdrawn).toBeLessThan(firstClaimed * 2n);
+
+    // sorobanWithdraw should only ever have been invoked once per HTTP call
+    // (i.e. the second call didn't silently no-op withdraw on-chain either).
+    expect(mockWithdraw).toHaveBeenCalledTimes(second.status === 200 ? 2 : 1);
+  });
 });


### PR DESCRIPTION
Closes #1290

## Summary

Adds the missing test coverage called out in the audit: no existing test called the withdraw endpoint twice in a row for the same stream/claimable window to check for `withdrawnAmount` double-counting (Functional Edge Case #14).

**Investigation result: no production bug found.** I wrote the test, ran it against current `main`, and it passes. I also deliberately sabotaged `backend/src/routes/v1/streams/withdraw.ts` (skipped the `lastUpdateTime` bump in the atomic SQL update, reproducing the exact double-counting failure mode) and reran the test — it failed as expected, confirming the test is a real, meaningful check and not a false positive. I then reverted the sabotage; **no changes were made to any source file**, only the test file.

Current code already prevents this bug: the atomic `UPDATE "Stream" SET "withdrawnAmount" = withdrawnAmount + $1, "lastUpdateTime" = $2` from the prior Issue #1217 fix advances `lastUpdateTime` on every withdraw, and `claimableAmountService.getClaimableAmount` recomputes `elapsed = now - lastUpdateTime` against the fresh row. So a second withdraw issued immediately after the first (same claim window) correctly finds ~0 elapsed time and returns `409 Conflict` instead of re-claiming the same window. This PR closes the test-coverage gap the issue identified; it is not a bug-fix PR.

## What changed

- `backend/tests/integration/streams/withdraw.test.ts`: added one new test, `does not double-count withdrawnAmount when the same claim window is withdrawn twice in a row`.

No other files were modified.

## Implementation details

The existing tests in this file mock `prisma` and `sorobanService` but use the **real** `claimableAmountService`, so claimable-amount math runs for real against whatever mocked DB state is set up. The new test builds on that by making the mock **stateful** instead of using two independent, hand-picked `mockResolvedValueOnce` stubs (which would let a test "pass" without actually exercising whether double-counting is possible):

- A single mutable `streamState` object represents the DB row (`depositedAmount: '10000000'`, `ratePerSecond: '100'`, `lastUpdateTime` set 5000s in the past so there's a large pending claimable balance).
- `mockPrisma.stream.findUnique` always returns a fresh copy of the *current* `streamState` — used both for the handler's initial read and the transaction's post-increment re-read.
- `mockPrisma.$executeRawUnsafe` is mocked to actually perform the increment the real SQL would (`withdrawnAmount += withdrawAmount`, `lastUpdateTime = now`) against `streamState`, so the second call's re-fetch genuinely reflects what the first call did.
- Also explicitly resets `mockPrisma.$transaction`'s implementation at the start of the test. (Found along the way: the pre-existing "successful withdraw" test in this file replaces `$transaction`'s implementation with one that queues a stray `findUnique.mockResolvedValueOnce(...)`, and `vi.clearAllMocks()` in `beforeEach` does not undo custom mock implementations — only call history. Without resetting it, that stale stub from an earlier test leaked into this one and produced a false failure. This is scoped to test setup only.)

The test then:
1. Calls `POST /v1/streams/:streamId/withdraw` once — asserts `200` and a claimable amount reflecting the full accrued window.
2. Calls it again immediately for the same stream/recipient.
3. Asserts the second call is either `409` (no claimable balance — the expected/observed outcome against current code) or, if some real wall-clock time legitimately elapsed between the two requests, a claim amount far smaller than the first (`< firstClaimed / 10`).
4. Asserts the final `withdrawnAmount` is `>= firstClaimed` and strictly `< firstClaimed * 2` — the core anti-double-counting assertion — and that `sorobanWithdraw` was only invoked as many times as HTTP calls actually reached the on-chain step.

## How to test

```bash
cd backend
npm install
npx prisma generate
npm run test:unit          # full unit suite — 315 passed, 3 skipped
npx vitest run tests/integration/streams/withdraw.test.ts   # just this file — 5 passed
npm run test:integration   # full integration suite — 72 passed, 13 skipped (pre-existing, Docker/Postgres-gated)
```

All suites pass unmodified against current `main` plus this test-only change.