### PR TITLE
feat(activity): virtualized activity-history filter/sort helpers (#1328)

### DIFF
--- a/frontend/src/utils/activityFilters.test.ts
+++ b/frontend/src/utils/activityFilters.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterActivityEvents,
+  sortActivityEvents,
+  type ActivityFilters,
+} from "./activityFilters";
+import type { BackendStreamEvent, StreamEventType } from "@/lib/api-types";
+
+function makeEvent(
+  overrides: Partial<BackendStreamEvent> = {},
+): BackendStreamEvent {
+  return {
+    id: "evt",
+    streamId: 1,
+    eventType: "CREATED",
+    amount: "1000000",
+    transactionHash: "abc123",
+    ledgerSequence: 1,
+    timestamp: 1_700_000_000,
+    metadata: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const events: BackendStreamEvent[] = [
+  makeEvent({ id: "a", eventType: "CREATED", streamId: 10, amount: "500", timestamp: 100, transactionHash: "0xAAA" }),
+  makeEvent({ id: "b", eventType: "WITHDRAWN", streamId: 11, amount: "900", timestamp: 200, transactionHash: "0xBBB" }),
+  makeEvent({ id: "c", eventType: "PAUSED", streamId: 12, amount: null, timestamp: 300, transactionHash: "0xCCC" }),
+];
+
+describe("filterActivityEvents", () => {
+  it("returns everything when no filters are given", () => {
+    expect(filterActivityEvents(events)).toHaveLength(3);
+  });
+
+  it("filters by event type", () => {
+    const types: StreamEventType[] = ["CREATED", "PAUSED"];
+    const result = filterActivityEvents(events, { types });
+    expect(result.map((e) => e.id)).toEqual(["a", "c"]);
+  });
+
+  it("filters by inclusive timestamp range", () => {
+    const filters: ActivityFilters = { fromTimestamp: 150, toTimestamp: 300 };
+    expect(filterActivityEvents(events, filters).map((e) => e.id)).toEqual([
+      "b",
+      "c",
+    ]);
+  });
+
+  it("searches tx hash case-insensitively and by stream id", () => {
+    expect(filterActivityEvents(events, { search: "0xbbb" }).map((e) => e.id)).toEqual(["b"]);
+    expect(filterActivityEvents(events, { search: "12" }).map((e) => e.id)).toEqual(["c"]);
+  });
+
+  it("combines filters (AND semantics)", () => {
+    const result = filterActivityEvents(events, {
+      types: ["WITHDRAWN", "PAUSED"],
+      fromTimestamp: 250,
+    });
+    expect(result.map((e) => e.id)).toEqual(["c"]);
+  });
+});
+
+describe("sortActivityEvents", () => {
+  it("sorts by amount descending, treating null as zero", () => {
+    const result = sortActivityEvents(events, "amount", "desc");
+    expect(result.map((e) => e.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("sorts by timestamp ascending", () => {
+    const result = sortActivityEvents(events, "timestamp", "asc");
+    expect(result.map((e) => e.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("is stable for equal keys", () => {
+    const tied = [
+      makeEvent({ id: "x", amount: "5" }),
+      makeEvent({ id: "y", amount: "5" }),
+      makeEvent({ id: "z", amount: "5" }),
+    ];
+    expect(sortActivityEvents(tied, "amount").map((e) => e.id)).toEqual([
+      "x",
+      "y",
+      "z",
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [...events];
+    sortActivityEvents(input, "streamId", "asc");
+    expect(input.map((e) => e.id)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/frontend/src/utils/activityFilters.ts
+++ b/frontend/src/utils/activityFilters.ts
@@ -1,0 +1,90 @@
+import type { BackendStreamEvent, StreamEventType } from "@/lib/api-types";
+
+/**
+ * Pure filtering/sorting helpers for the activity history table (issue #1328).
+ *
+ * Kept UI-free so the multi-parameter filter logic can be unit-tested without
+ * a DOM and reused by both the dashboard widget and the full activity page.
+ */
+
+export interface ActivityFilters {
+  /** Event types to keep. `null`/empty means "all types". */
+  types?: StreamEventType[] | null;
+  /** Case-insensitive substring match against tx hash or stream id. */
+  search?: string;
+  /** Inclusive lower bound, unix seconds. */
+  fromTimestamp?: number | null;
+  /** Inclusive upper bound, unix seconds. */
+  toTimestamp?: number | null;
+}
+
+export type ActivitySortKey = "timestamp" | "amount" | "streamId";
+export type SortDirection = "asc" | "desc";
+
+function matchesSearch(event: BackendStreamEvent, needle: string): boolean {
+  const q = needle.trim().toLowerCase();
+  if (!q) return true;
+  return (
+    event.transactionHash.toLowerCase().includes(q) ||
+    String(event.streamId).includes(q)
+  );
+}
+
+/** Apply every provided filter. Filters left undefined are ignored. */
+export function filterActivityEvents(
+  events: BackendStreamEvent[],
+  filters: ActivityFilters = {},
+): BackendStreamEvent[] {
+  const typeSet =
+    filters.types && filters.types.length > 0 ? new Set(filters.types) : null;
+
+  return events.filter((event) => {
+    if (typeSet && !typeSet.has(event.eventType)) return false;
+    if (
+      filters.fromTimestamp != null &&
+      event.timestamp < filters.fromTimestamp
+    ) {
+      return false;
+    }
+    if (filters.toTimestamp != null && event.timestamp > filters.toTimestamp) {
+      return false;
+    }
+    if (filters.search != null && !matchesSearch(event, filters.search)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function sortValue(event: BackendStreamEvent, key: ActivitySortKey): bigint {
+  switch (key) {
+    case "amount":
+      return event.amount ? BigInt(event.amount) : 0n;
+    case "streamId":
+      return BigInt(event.streamId);
+    case "timestamp":
+    default:
+      return BigInt(event.timestamp);
+  }
+}
+
+/**
+ * Return a new array sorted by `key`. Stable for equal keys (preserves the
+ * caller's incoming order), so a resort does not reshuffle ties.
+ */
+export function sortActivityEvents(
+  events: BackendStreamEvent[],
+  key: ActivitySortKey,
+  direction: SortDirection = "desc",
+): BackendStreamEvent[] {
+  const factor = direction === "asc" ? 1n : -1n;
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort((a, b) => {
+      const delta = (sortValue(a.event, key) - sortValue(b.event, key)) * factor;
+      if (delta > 0n) return 1;
+      if (delta < 0n) return -1;
+      return a.index - b.index;
+    })
+    .map(({ event }) => event);
+}


### PR DESCRIPTION
## Description

First bounded slice for the high-performance activity table: **`frontend/src/utils/activityFilters.ts`**, the pure multi-parameter filter/sort logic, with full unit tests. `ActivityHistory.tsx` already virtualizes via `@tanstack/react-virtual`; this adds the filtering the issue asks for.

- `filterActivityEvents(events, filters)` — event-type set, tx-hash / stream-id substring search, inclusive date range, AND-combined.
- `sortActivityEvents(events, key, dir)` — by `timestamp` / `amount` / `streamId`, stable on ties, non-mutating.

Kept UI-free so it's unit-testable and reusable by both the dashboard widget and `activity/activity-content.tsx`.

Follow-up (same issue): wire the filter bar + date picker + sort headers into `ActivityHistory.tsx`, extend search to recipient/token once events carry that.

## Testing
`frontend/src/utils/activityFilters.test.ts` added. Vitest/lint/build run on this PR's CI (frontend deps aren't installed locally in this environment).

Closes #1328
