### PR TITLE
fix(frontend): cancel exponential-backoff poll on unmount/wallet chan…

### DIFF
--- a/frontend/src/hooks/useIncomingStreams.test.tsx
+++ b/frontend/src/hooks/useIncomingStreams.test.tsx
@@ -146,5 +146,50 @@ describe("useIncomingStreams hooks", () => {
         queryKey: incomingStreamsQueryKey("pubkey"),
       });
     });
+
+    it("aborts polling when the component unmounts mid-backoff", async () => {
+      vi.useFakeTimers();
+      vi.mocked(withdrawFromStream).mockResolvedValue({ success: true, txHash: "tx-hash" });
+      // fetchIncomingStreams resolves with an empty array so the poll never
+      // finds a matching stream and keeps retrying.
+      vi.mocked(fetchIncomingStreams).mockResolvedValue([]);
+
+      const { result, unmount } = renderHook(
+        () => useWithdrawIncomingStream({} as unknown as WalletSession, "pubkey"),
+        { wrapper }
+      );
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          id: "1",
+          streamId: 1,
+          withdrawn: 0,
+          deposited: 100,
+          ratePerSecond: 1,
+          isPaused: false,
+          lastUpdateTime: Date.now() / 1000,
+        } as unknown as IncomingStreamRecord);
+      });
+
+      // Let the first poll iteration fire (1 s delay)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+
+      const callsBeforeUnmount = vi.mocked(fetchIncomingStreams).mock.calls.length;
+
+      // Unmount the component – this should abort the poll controller
+      unmount();
+
+      // Advance well past all remaining retries
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(63_000);
+      });
+
+      // No additional fetches should have been made after unmount
+      expect(vi.mocked(fetchIncomingStreams).mock.calls.length).toBe(
+        callsBeforeUnmount,
+      );
+    });
   });
 });

--- a/frontend/src/hooks/useIncomingStreams.ts
+++ b/frontend/src/hooks/useIncomingStreams.ts
@@ -1,6 +1,11 @@
 "use client";
 
 import {
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
+import {
   useMutation,
   useQuery,
   useQueryClient,
@@ -50,6 +55,43 @@ export function useWithdrawIncomingStream(
   },
 ) {
   const queryClient = useQueryClient();
+
+  // Ref to the active poll AbortController so we can cancel on unmount/
+  // wallet change. Each mutation resets it.
+  const pollControllerRef = useRef<AbortController | null>(null);
+
+  // Abort any in-flight poll when the component unmounts or the wallet
+  // changes.  This prevents stale fetches and state writes.
+  useEffect(() => {
+    return () => {
+      pollControllerRef.current?.abort();
+      pollControllerRef.current = null;
+    };
+  }, [publicKey]);
+
+  const pollIndexer = useCallback(
+    (
+      pk: string,
+      streamId: number,
+      oldWithdrawn: number,
+      expectedWithdrawn: number,
+    ) => {
+      // Abort any previous poll that may still be running
+      pollControllerRef.current?.abort();
+      const controller = new AbortController();
+      pollControllerRef.current = controller;
+
+      pollIndexerForWithdraw(
+        pk,
+        streamId,
+        oldWithdrawn,
+        expectedWithdrawn,
+        queryClient,
+        controller.signal,
+      );
+    },
+    [queryClient],
+  );
 
   return useMutation({
     mutationFn: async (stream: IncomingStreamRecord) => {
@@ -116,12 +158,11 @@ export function useWithdrawIncomingStream(
         };
         const targetWithdrawn = ctx.expectedWithdrawn ?? stream.withdrawn;
         // Start polling in the background without blocking the mutation
-        pollIndexerForWithdraw(
+        pollIndexer(
           publicKey,
           stream.streamId,
           stream.withdrawn,
           targetWithdrawn,
-          queryClient,
         );
       }
 
@@ -149,14 +190,25 @@ async function pollIndexerForWithdraw(
   oldWithdrawn: number,
   expectedWithdrawn: number,
   queryClient: ReturnType<typeof useQueryClient>,
+  signal?: AbortSignal,
   maxRetries = 6,
   initialDelay = 1000,
 ) {
   let delay = initialDelay;
   for (let attempt = 0; attempt < maxRetries; attempt++) {
+    // Stop immediately if the caller has aborted (unmount / wallet change)
+    if (signal?.aborted) return;
+
     await new Promise((resolve) => setTimeout(resolve, delay));
+
+    // Re-check after the delay – the signal may have been aborted while we
+    // were waiting.
+    if (signal?.aborted) return;
+
     try {
       const streams = await fetchIncomingStreams(publicKey);
+      if (signal?.aborted) return;
+
       const updatedStream = streams.find((s) => s.streamId === streamId);
       if (
         updatedStream &&
@@ -167,11 +219,16 @@ async function pollIndexerForWithdraw(
         return;
       }
     } catch (err) {
+      // AbortError is expected when the signal fires; don't log it as a
+      // warning.
+      if (signal?.aborted) return;
       logger.warn("Error polling indexer for withdraw:", err);
     }
     delay *= 2;
   }
-  await queryClient.invalidateQueries({
-    queryKey: incomingStreamsQueryKey(publicKey),
-  });
+  if (!signal?.aborted) {
+    await queryClient.invalidateQueries({
+      queryKey: incomingStreamsQueryKey(publicKey),
+    });
+  }
 }


### PR DESCRIPTION
…ge (#1209)

The pollIndexerForWithdraw loop could run for ~63s with no abort mechanism, causing stale fetches and state writes after the user navigated away or switched wallets.

- Thread an AbortController through the polling loop via a useRef
- Abort on component unmount and wallet/publicKey change via useEffect cleanup
- Check signal.aborted before each fetch, state update, and after delay
- Add test verifying unmount mid-backoff stops further fetches


## Description
<!-- Provide a clear and concise description of what this PR does -->

## Type of Change
<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [x] 🧪 Test addition or update

## Related Issues
<!-- Link related issues using keywords like "Closes", "Fixes", "Resolves" -->
<!-- Example: Closes #123, Fixes #456 -->

Closes #1209

## Changes Made
<!-- Describe the specific changes made in this PR -->

## Testing
<!-- Describe the tests you ran and how to verify your changes -->

### Test Coverage
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

### Test Steps
<!-- If applicable, provide steps to test the changes -->
1. 
2. 
3. 

## Breaking Changes
<!-- If this PR includes breaking changes, describe them here -->
<!-- If none, you can remove this section -->

**Breaking Changes:**
- 

**Migration Guide:**
<!-- If applicable, provide steps for users to migrate -->

## Screenshots/Demo
<!-- If applicable, add screenshots or a link to a demo -->

## Checklist
<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Updated Postman/Hoppscotch API collections if routes changed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked for breaking changes and documented them if applicable

## Additional Notes
<!-- Any additional information that reviewers should know -->
