### PR TITLE
feat: Multi-Signature Dispute & Escrow Resolution (#1319)

### DIFF
--- a/contracts/stream_contract/src/errors.rs
+++ b/contracts/stream_contract/src/errors.rs
@@ -42,4 +42,14 @@ pub enum StreamError {
     /// Returned instead of letting `overflow-checks` panic and abort the whole
     /// transaction, so callers get a typed failure they can handle.
     ArithmeticOverflow = 16,
+    /// Stream has no arbiter configured; dispute operations are unavailable.
+    NoArbiterConfigured = 17,
+    /// A dispute is already active on this stream.
+    DisputeAlreadyActive = 18,
+    /// No active dispute exists on this stream.
+    NoActiveDispute = 19,
+    /// The payout split does not equal the remaining deposit.
+    InvalidDisputeSplit = 20,
+    /// Operation is blocked because a dispute is currently active on this stream.
+    DisputeInProgress = 21,
 }

--- a/contracts/stream_contract/src/events.rs
+++ b/contracts/stream_contract/src/events.rs
@@ -166,3 +166,26 @@ pub struct StreamCompletedEvent {
     pub recipient: Address,
     pub total_withdrawn: i128,
 }
+
+/// Emitted when a dispute is initiated on an escrow-enabled stream.
+///
+/// Topic: `("dispute_initiated", stream_id)`
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisputeInitiatedEvent {
+    pub stream_id: u64,
+    pub initiator: Address,
+    pub timestamp: u64,
+}
+
+/// Emitted when an arbiter resolves a dispute and splits the remaining funds.
+///
+/// Topic: `("dispute_resolved", stream_id)`
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisputeResolvedEvent {
+    pub stream_id: u64,
+    pub arbiter: Address,
+    pub sender_payout: i128,
+    pub recipient_payout: i128,
+}

--- a/contracts/stream_contract/src/lib.rs
+++ b/contracts/stream_contract/src/lib.rs
@@ -48,7 +48,9 @@ use storage::{
     config_exists, load_config, load_stream, next_stream_id, save_config, save_stream,
     try_load_config, try_load_stream,
 };
-use types::{BatchStreamInput, DisputeInitiatedData, DisputeState, ProtocolConfig, Stream, StreamStatus};
+use types::{
+    BatchStreamInput, DisputeInitiatedData, DisputeState, ProtocolConfig, Stream, StreamStatus,
+};
 
 /// Maximum allowed protocol fee: 1 000 bps = 10%.
 const MAX_FEE_RATE_BPS: u32 = 1_000;
@@ -1047,11 +1049,7 @@ impl StreamContract {
     /// - `StreamNotActive`      — stream is inactive.
     /// - `NoArbiterConfigured`  — stream has no arbiter.
     /// - `DisputeAlreadyActive` — a dispute is already in progress.
-    pub fn initiate_dispute(
-        env: Env,
-        caller: Address,
-        stream_id: u64,
-    ) -> Result<(), StreamError> {
+    pub fn initiate_dispute(env: Env, caller: Address, stream_id: u64) -> Result<(), StreamError> {
         caller.require_auth();
 
         let mut stream = load_stream(&env, stream_id)?;

--- a/contracts/stream_contract/src/lib.rs
+++ b/contracts/stream_contract/src/lib.rs
@@ -39,15 +39,16 @@ use soroban_sdk::{contract, contractimpl, token, vec, Address, Env, InvokeError,
 
 use errors::StreamError;
 use events::{
-    AdminTransferredEvent, FeeCollectedEvent, FeeConfigUpdatedEvent, InitializedEvent,
-    RecipientTransferredEvent, StreamCancelledEvent, StreamCompletedEvent, StreamCreatedEvent,
-    StreamPausedEvent, StreamResumedEvent, StreamToppedUpEvent, TokensWithdrawnEvent,
+    AdminTransferredEvent, DisputeInitiatedEvent, DisputeResolvedEvent, FeeCollectedEvent,
+    FeeConfigUpdatedEvent, InitializedEvent, RecipientTransferredEvent, StreamCancelledEvent,
+    StreamCompletedEvent, StreamCreatedEvent, StreamPausedEvent, StreamResumedEvent,
+    StreamToppedUpEvent, TokensWithdrawnEvent,
 };
 use storage::{
     config_exists, load_config, load_stream, next_stream_id, save_config, save_stream,
     try_load_config, try_load_stream,
 };
-use types::{BatchStreamInput, ProtocolConfig, Stream, StreamStatus};
+use types::{BatchStreamInput, DisputeInitiatedData, DisputeState, ProtocolConfig, Stream, StreamStatus};
 
 /// Maximum allowed protocol fee: 1 000 bps = 10%.
 const MAX_FEE_RATE_BPS: u32 = 1_000;
@@ -263,6 +264,8 @@ impl StreamContract {
                 paused: false,
                 paused_at: None,
                 status: StreamStatus::Active,
+                arbiter: None,
+                dispute_state: DisputeState::None,
             },
         );
 
@@ -356,6 +359,8 @@ impl StreamContract {
                 paused: false,
                 paused_at: None,
                 status: StreamStatus::Active,
+                arbiter: None,
+                dispute_state: DisputeState::None,
             };
             save_stream(&env, stream_id, &stream);
             env.events().publish(
@@ -419,6 +424,8 @@ impl StreamContract {
                 paused: false,
                 paused_at: None,
                 status: StreamStatus::Active,
+                arbiter: None,
+                dispute_state: DisputeState::None,
             },
         );
         env.events().publish(
@@ -785,6 +792,11 @@ impl StreamContract {
         Self::validate_stream_ownership(&stream, &sender)?;
         Self::validate_stream_active(&stream)?;
 
+        // Block unilateral cancellation if a dispute is in progress.
+        if let DisputeState::Initiated(_) = &stream.dispute_state {
+            return Err(StreamError::DisputeInProgress);
+        }
+
         let now = env.ledger().timestamp();
         let accrued_amount = Self::calculate_claimable(&stream, now);
 
@@ -940,6 +952,240 @@ impl StreamContract {
         );
 
         Ok(new_end_time)
+    }
+
+    // ─── Escrow & Dispute Resolution ──────────────────────────────────────────
+
+    /// Create a new escrow-enabled payment stream with an arbiter.
+    ///
+    /// Identical to `create_stream` but accepts an `arbiter` address that can
+    /// mediate disputes. Either party can initiate a dispute, which freezes
+    /// accrual and blocks unilateral cancellation until the arbiter resolves it.
+    ///
+    /// # Errors
+    /// Same as `create_stream`.
+    pub fn create_escrow_stream(
+        env: Env,
+        sender: Address,
+        recipient: Address,
+        token_address: Address,
+        amount: i128,
+        duration: u64,
+        arbiter: Address,
+    ) -> Result<u64, StreamError> {
+        sender.require_auth();
+
+        if amount <= 0 {
+            return Err(StreamError::InvalidAmount);
+        }
+        if duration == 0 {
+            return Err(StreamError::InvalidDuration);
+        }
+        Self::validate_token_contract(&env, &token_address)?;
+
+        let stream_id = next_stream_id(&env);
+        let start_time = env.ledger().timestamp();
+
+        let token_client = token::Client::new(&env, &token_address);
+        let contract_address = env.current_contract_address();
+        token_client.transfer(&sender, &contract_address, &amount);
+
+        let net_amount = Self::collect_fee(&env, &token_address, amount, stream_id)?;
+        let rate_per_second = net_amount / (duration as i128);
+
+        if rate_per_second == 0 {
+            return Err(StreamError::InvalidRate);
+        }
+
+        save_stream(
+            &env,
+            stream_id,
+            &Stream {
+                sender: sender.clone(),
+                recipient: recipient.clone(),
+                token_address: token_address.clone(),
+                rate_per_second,
+                deposited_amount: net_amount,
+                withdrawn_amount: 0,
+                start_time,
+                last_update_time: start_time,
+                cliff_time: None,
+                is_active: true,
+                paused: false,
+                paused_at: None,
+                status: StreamStatus::Active,
+                arbiter: Some(arbiter),
+                dispute_state: DisputeState::None,
+            },
+        );
+
+        env.events().publish(
+            (Symbol::new(&env, "stream_created"), stream_id),
+            StreamCreatedEvent {
+                stream_id,
+                sender,
+                recipient,
+                rate_per_second,
+                token_address,
+                deposited_amount: net_amount,
+                start_time,
+            },
+        );
+
+        Ok(stream_id)
+    }
+
+    /// Initiate a dispute on an escrow-enabled stream.
+    ///
+    /// Either the sender or recipient can initiate. Once initiated, token
+    /// accrual is frozen (stream is paused) and unilateral cancellation or
+    /// withdrawal is blocked until the arbiter resolves the dispute.
+    ///
+    /// # Errors
+    /// - `StreamNotFound`       — no stream exists with `stream_id`.
+    /// - `Unauthorized`         — caller is neither sender nor recipient.
+    /// - `StreamNotActive`      — stream is inactive.
+    /// - `NoArbiterConfigured`  — stream has no arbiter.
+    /// - `DisputeAlreadyActive` — a dispute is already in progress.
+    pub fn initiate_dispute(
+        env: Env,
+        caller: Address,
+        stream_id: u64,
+    ) -> Result<(), StreamError> {
+        caller.require_auth();
+
+        let mut stream = load_stream(&env, stream_id)?;
+
+        // Only sender or recipient may initiate.
+        if stream.sender != caller && stream.recipient != caller {
+            return Err(StreamError::Unauthorized);
+        }
+        if !stream.is_active {
+            return Err(StreamError::StreamNotActive);
+        }
+        if stream.arbiter.is_none() {
+            return Err(StreamError::NoArbiterConfigured);
+        }
+        if let DisputeState::Initiated(_) = &stream.dispute_state {
+            return Err(StreamError::DisputeAlreadyActive);
+        }
+
+        let now = env.ledger().timestamp();
+
+        // Freeze accrual by pausing the stream at the dispute moment.
+        if !stream.paused {
+            stream.paused = true;
+            stream.paused_at = Some(now);
+            stream.status = StreamStatus::Paused;
+        }
+
+        stream.dispute_state = DisputeState::Initiated(DisputeInitiatedData {
+            initiator: caller.clone(),
+            timestamp: now,
+        });
+        save_stream(&env, stream_id, &stream);
+
+        env.events().publish(
+            (Symbol::new(&env, "dispute_initiated"), stream_id),
+            DisputeInitiatedEvent {
+                stream_id,
+                initiator: caller,
+                timestamp: now,
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Resolve an active dispute as the designated arbiter.
+    ///
+    /// The arbiter splits the remaining deposit (after already-withdrawn
+    /// amounts) between sender and recipient. The split must be exact:
+    /// `sender_payout + recipient_payout == remaining_deposit`.
+    ///
+    /// Both payouts are transferred atomically and the stream is terminated.
+    ///
+    /// # Errors
+    /// - `StreamNotFound`      — no stream exists with `stream_id`.
+    /// - `Unauthorized`        — caller is not the stream's arbiter.
+    /// - `NoActiveDispute`     — no dispute is in progress.
+    /// - `InvalidDisputeSplit` — payouts do not sum to remaining deposit.
+    pub fn resolve_dispute(
+        env: Env,
+        arbiter: Address,
+        stream_id: u64,
+        sender_payout: i128,
+        recipient_payout: i128,
+    ) -> Result<(), StreamError> {
+        arbiter.require_auth();
+
+        let mut stream = load_stream(&env, stream_id)?;
+
+        // Verify the caller is the stream's arbiter.
+        match &stream.arbiter {
+            Some(a) if *a == arbiter => {}
+            _ => return Err(StreamError::Unauthorized),
+        }
+
+        // Verify a dispute is active.
+        match &stream.dispute_state {
+            DisputeState::Initiated(_) => {}
+            _ => return Err(StreamError::NoActiveDispute),
+        }
+
+        // The remaining deposit is everything not yet withdrawn.
+        let remaining = stream
+            .deposited_amount
+            .saturating_sub(stream.withdrawn_amount);
+
+        // Enforce exact split.
+        if sender_payout < 0 || recipient_payout < 0 {
+            return Err(StreamError::InvalidDisputeSplit);
+        }
+        if sender_payout
+            .checked_add(recipient_payout)
+            .ok_or(StreamError::ArithmeticOverflow)?
+            != remaining
+        {
+            return Err(StreamError::InvalidDisputeSplit);
+        }
+
+        // Effects: terminate the stream.
+        stream.is_active = false;
+        stream.status = StreamStatus::Cancelled;
+        stream.paused = false;
+        stream.paused_at = Option::None;
+        stream.dispute_state = DisputeState::Resolved;
+        stream.withdrawn_amount = stream.deposited_amount;
+
+        let sender_addr = stream.sender.clone();
+        let recipient_addr = stream.recipient.clone();
+
+        // Persist state before external calls (CEI).
+        save_stream(&env, stream_id, &stream);
+
+        // Interactions: transfer payouts.
+        let token_client = token::Client::new(&env, &stream.token_address);
+        let contract_address = env.current_contract_address();
+
+        if sender_payout > 0 {
+            token_client.transfer(&contract_address, &sender_addr, &sender_payout);
+        }
+        if recipient_payout > 0 {
+            token_client.transfer(&contract_address, &recipient_addr, &recipient_payout);
+        }
+
+        env.events().publish(
+            (Symbol::new(&env, "dispute_resolved"), stream_id),
+            DisputeResolvedEvent {
+                stream_id,
+                arbiter,
+                sender_payout,
+                recipient_payout,
+            },
+        );
+
+        Ok(())
     }
 
     // ─── Read-only Queries ────────────────────────────────────────────────────

--- a/contracts/stream_contract/src/test.rs
+++ b/contracts/stream_contract/src/test.rs
@@ -3154,15 +3154,14 @@ fn test_initiate_dispute_by_sender_succeeds() {
     let arbiter = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
 
     client.initiate_dispute(&sender, &id);
 
     let stream = client.get_stream(&id).unwrap();
-    assert!(matches!(
-        stream.dispute_state,
-        DisputeState::Initiated(_)
-    ));
+    assert!(matches!(stream.dispute_state, DisputeState::Initiated(_)));
     assert!(stream.paused);
     assert_eq!(stream.status, StreamStatus::Paused);
 }
@@ -3178,15 +3177,14 @@ fn test_initiate_dispute_by_recipient_succeeds() {
     let arbiter = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
 
     client.initiate_dispute(&recipient, &id);
 
     let stream = client.get_stream(&id).unwrap();
-    assert!(matches!(
-        stream.dispute_state,
-        DisputeState::Initiated(_)
-    ));
+    assert!(matches!(stream.dispute_state, DisputeState::Initiated(_)));
 }
 
 #[test]
@@ -3201,7 +3199,9 @@ fn test_initiate_dispute_unauthorized_caller_fails() {
     let stranger = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
 
     assert_eq!(
         client.try_initiate_dispute(&stranger, &id),
@@ -3239,7 +3239,9 @@ fn test_initiate_dispute_already_active_fails() {
     let arbiter = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
 
     client.initiate_dispute(&sender, &id);
 
@@ -3275,7 +3277,9 @@ fn test_initiate_dispute_emits_event() {
     let arbiter = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
 
     client.initiate_dispute(&sender, &id);
 
@@ -3312,7 +3316,9 @@ fn test_resolve_dispute_arbiter_splits_funds() {
     let arbiter = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
 
     client.initiate_dispute(&sender, &id);
 
@@ -3340,7 +3346,9 @@ fn test_resolve_dispute_full_to_sender() {
     let arbiter = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
     client.initiate_dispute(&sender, &id);
     client.resolve_dispute(&arbiter, &id, &10_000, &0);
 
@@ -3360,7 +3368,9 @@ fn test_resolve_dispute_full_to_recipient() {
     let arbiter = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
     client.initiate_dispute(&sender, &id);
     client.resolve_dispute(&arbiter, &id, &0, &10_000);
 
@@ -3381,7 +3391,9 @@ fn test_resolve_dispute_unauthorized_non_arbiter_fails() {
     let stranger = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
     client.initiate_dispute(&sender, &id);
 
     assert_eq!(
@@ -3401,7 +3413,9 @@ fn test_resolve_dispute_no_active_dispute_fails() {
     let arbiter = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
 
     // No dispute initiated — resolve should fail.
     assert_eq!(
@@ -3421,7 +3435,9 @@ fn test_resolve_dispute_invalid_split_fails() {
     let arbiter = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
     client.initiate_dispute(&sender, &id);
 
     // 6_000 + 3_000 = 9_000 ≠ 10_000 remaining → invalid.
@@ -3442,7 +3458,9 @@ fn test_resolve_dispute_negative_payout_fails() {
     let arbiter = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
     client.initiate_dispute(&sender, &id);
 
     assert_eq!(
@@ -3462,7 +3480,9 @@ fn test_resolve_dispute_emits_event() {
     let arbiter = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
     client.initiate_dispute(&sender, &id);
     client.resolve_dispute(&arbiter, &id, &7_000, &3_000);
 
@@ -3501,7 +3521,9 @@ fn test_cancel_blocked_during_active_dispute() {
     let arbiter = Address::generate(&env);
     let client = create_contract(&env);
 
-    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    let id = create_escrow_stream(
+        &env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100,
+    );
     client.initiate_dispute(&sender, &id);
 
     // Unilateral cancel must be blocked while dispute is active.

--- a/contracts/stream_contract/src/test.rs
+++ b/contracts/stream_contract/src/test.rs
@@ -10,11 +10,12 @@ use soroban_sdk::{
 
 use errors::StreamError;
 use events::{
-    AdminTransferredEvent, FeeCollectedEvent, FeeConfigUpdatedEvent, InitializedEvent,
-    StreamCancelledEvent, StreamCompletedEvent, StreamCreatedEvent, StreamPausedEvent,
-    StreamResumedEvent, StreamToppedUpEvent, TokensWithdrawnEvent,
+    AdminTransferredEvent, DisputeInitiatedEvent, DisputeResolvedEvent, FeeCollectedEvent,
+    FeeConfigUpdatedEvent, InitializedEvent, StreamCancelledEvent, StreamCompletedEvent,
+    StreamCreatedEvent, StreamPausedEvent, StreamResumedEvent, StreamToppedUpEvent,
+    TokensWithdrawnEvent,
 };
-use types::{DataKey, Stream, StreamStatus};
+use types::{DataKey, DisputeInitiatedData, DisputeState, Stream, StreamStatus};
 
 // ─── Test Helpers ─────────────────────────────────────────────────────────────
 
@@ -73,6 +74,8 @@ fn test_datakey_stream_serializes_deterministically() {
         paused: false,
         paused_at: None,
         status: StreamStatus::Active,
+        arbiter: None,
+        dispute_state: DisputeState::None,
     };
     env.as_contract(&contract_id, || {
         env.storage().persistent().set(&key, &stream);
@@ -2271,6 +2274,8 @@ fn test_fuzz_claimable_overflow_and_cancel_invariants() {
             } else {
                 StreamStatus::Active
             },
+            arbiter: None,
+            dispute_state: DisputeState::None,
         };
 
         let claimable = StreamContract::calculate_claimable(&stream, elapsed);
@@ -3112,5 +3117,396 @@ fn test_resume_rejects_end_time_projection_overflow() {
     assert_eq!(
         client.try_resume_stream(&sender, &id),
         Err(Ok(StreamError::ArithmeticOverflow))
+    );
+}
+
+// ─── Dispute Tests (Issue #1319) ──────────────────────────────────────────────
+
+/// Helper: creates a stream with an arbiter configured via force_stream.
+fn create_escrow_stream(
+    env: &Env,
+    client: &StreamContractClient<'_>,
+    sender: &Address,
+    recipient: &Address,
+    token: &Address,
+    arbiter: &Address,
+    amount: i128,
+    duration: u64,
+) -> u64 {
+    mint(env, token, sender, amount);
+    let id = client.create_stream(sender, recipient, token, &amount, &duration);
+    let mut stream = client.get_stream(&id).unwrap();
+    stream.arbiter = Some(arbiter.clone());
+    force_stream(env, client, id, &stream);
+    id
+}
+
+// ─── initiate_dispute ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_initiate_dispute_by_sender_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+
+    client.initiate_dispute(&sender, &id);
+
+    let stream = client.get_stream(&id).unwrap();
+    assert!(matches!(
+        stream.dispute_state,
+        DisputeState::Initiated(_)
+    ));
+    assert!(stream.paused);
+    assert_eq!(stream.status, StreamStatus::Paused);
+}
+
+#[test]
+fn test_initiate_dispute_by_recipient_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+
+    client.initiate_dispute(&recipient, &id);
+
+    let stream = client.get_stream(&id).unwrap();
+    assert!(matches!(
+        stream.dispute_state,
+        DisputeState::Initiated(_)
+    ));
+}
+
+#[test]
+fn test_initiate_dispute_unauthorized_caller_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+
+    assert_eq!(
+        client.try_initiate_dispute(&stranger, &id),
+        Err(Ok(StreamError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_initiate_dispute_no_arbiter_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let client = create_contract(&env);
+
+    mint(&env, &token, &sender, 10_000);
+    let id = client.create_stream(&sender, &recipient, &token, &10_000, &100);
+
+    assert_eq!(
+        client.try_initiate_dispute(&sender, &id),
+        Err(Ok(StreamError::NoArbiterConfigured))
+    );
+}
+
+#[test]
+fn test_initiate_dispute_already_active_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+
+    client.initiate_dispute(&sender, &id);
+
+    // Second initiate should fail.
+    assert_eq!(
+        client.try_initiate_dispute(&recipient, &id),
+        Err(Ok(StreamError::DisputeAlreadyActive))
+    );
+}
+
+#[test]
+fn test_initiate_dispute_stream_not_found_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = create_contract(&env);
+    let caller = Address::generate(&env);
+
+    assert_eq!(
+        client.try_initiate_dispute(&caller, &999_u64),
+        Err(Ok(StreamError::StreamNotFound))
+    );
+}
+
+#[test]
+fn test_initiate_dispute_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+
+    client.initiate_dispute(&sender, &id);
+
+    let events = env.events().all();
+    let (_topics, data) = events
+        .iter()
+        .rev()
+        .find_map(|(_, t, d)| {
+            let t_vec: soroban_sdk::Vec<soroban_sdk::Val> = t.clone().into();
+            if let Ok(sym) = Symbol::try_from_val(&env, &t_vec.get(0).unwrap()) {
+                if sym == Symbol::new(&env, "dispute_initiated") {
+                    return Some((t, d));
+                }
+            }
+            None
+        })
+        .expect("dispute_initiated event not found");
+
+    let evt = DisputeInitiatedEvent::try_from_val(&env, &data).unwrap();
+    assert_eq!(evt.stream_id, id);
+    assert_eq!(evt.initiator, sender);
+}
+
+// ─── resolve_dispute ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_resolve_dispute_arbiter_splits_funds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+
+    client.initiate_dispute(&sender, &id);
+
+    // Arbiter splits 10_000 → 6_000 to sender, 4_000 to recipient.
+    client.resolve_dispute(&arbiter, &id, &6_000, &4_000);
+
+    let stream = client.get_stream(&id).unwrap();
+    assert_eq!(stream.dispute_state, DisputeState::Resolved);
+    assert!(!stream.is_active);
+    assert_eq!(stream.status, StreamStatus::Cancelled);
+
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&sender), 6_000);
+    assert_eq!(token_client.balance(&recipient), 4_000);
+}
+
+#[test]
+fn test_resolve_dispute_full_to_sender() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    client.initiate_dispute(&sender, &id);
+    client.resolve_dispute(&arbiter, &id, &10_000, &0);
+
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&sender), 10_000);
+    assert_eq!(token_client.balance(&recipient), 0);
+}
+
+#[test]
+fn test_resolve_dispute_full_to_recipient() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    client.initiate_dispute(&sender, &id);
+    client.resolve_dispute(&arbiter, &id, &0, &10_000);
+
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&sender), 0);
+    assert_eq!(token_client.balance(&recipient), 10_000);
+}
+
+#[test]
+fn test_resolve_dispute_unauthorized_non_arbiter_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    client.initiate_dispute(&sender, &id);
+
+    assert_eq!(
+        client.try_resolve_dispute(&stranger, &id, &5_000, &5_000),
+        Err(Ok(StreamError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_resolve_dispute_no_active_dispute_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+
+    // No dispute initiated — resolve should fail.
+    assert_eq!(
+        client.try_resolve_dispute(&arbiter, &id, &5_000, &5_000),
+        Err(Ok(StreamError::NoActiveDispute))
+    );
+}
+
+#[test]
+fn test_resolve_dispute_invalid_split_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    client.initiate_dispute(&sender, &id);
+
+    // 6_000 + 3_000 = 9_000 ≠ 10_000 remaining → invalid.
+    assert_eq!(
+        client.try_resolve_dispute(&arbiter, &id, &6_000, &3_000),
+        Err(Ok(StreamError::InvalidDisputeSplit))
+    );
+}
+
+#[test]
+fn test_resolve_dispute_negative_payout_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    client.initiate_dispute(&sender, &id);
+
+    assert_eq!(
+        client.try_resolve_dispute(&arbiter, &id, &-1, &10_001),
+        Err(Ok(StreamError::InvalidDisputeSplit))
+    );
+}
+
+#[test]
+fn test_resolve_dispute_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    client.initiate_dispute(&sender, &id);
+    client.resolve_dispute(&arbiter, &id, &7_000, &3_000);
+
+    let events = env.events().all();
+    let (_, data) = events
+        .iter()
+        .rev()
+        .find_map(|(_, t, d)| {
+            let t_vec: soroban_sdk::Vec<soroban_sdk::Val> = t.clone().into();
+            if let Ok(sym) = Symbol::try_from_val(&env, &t_vec.get(0).unwrap()) {
+                if sym == Symbol::new(&env, "dispute_resolved") {
+                    return Some((t, d));
+                }
+            }
+            None
+        })
+        .expect("dispute_resolved event not found");
+
+    let evt = DisputeResolvedEvent::try_from_val(&env, &data).unwrap();
+    assert_eq!(evt.stream_id, id);
+    assert_eq!(evt.arbiter, arbiter);
+    assert_eq!(evt.sender_payout, 7_000);
+    assert_eq!(evt.recipient_payout, 3_000);
+}
+
+// ─── Dispute blocks cancel ────────────────────────────────────────────────────
+
+#[test]
+fn test_cancel_blocked_during_active_dispute() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _) = create_token(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let client = create_contract(&env);
+
+    let id = create_escrow_stream(&env, &client, &sender, &recipient, &token, &arbiter, 10_000, 100);
+    client.initiate_dispute(&sender, &id);
+
+    // Unilateral cancel must be blocked while dispute is active.
+    assert_eq!(
+        client.try_cancel_stream(&sender, &id),
+        Err(Ok(StreamError::DisputeInProgress))
     );
 }

--- a/contracts/stream_contract/src/test.rs
+++ b/contracts/stream_contract/src/test.rs
@@ -15,7 +15,7 @@ use events::{
     StreamCreatedEvent, StreamPausedEvent, StreamResumedEvent, StreamToppedUpEvent,
     TokensWithdrawnEvent,
 };
-use types::{DataKey, DisputeInitiatedData, DisputeState, Stream, StreamStatus};
+use types::{DataKey, DisputeState, Stream, StreamStatus};
 
 // ─── Test Helpers ─────────────────────────────────────────────────────────────
 
@@ -3123,6 +3123,7 @@ fn test_resume_rejects_end_time_projection_overflow() {
 // ─── Dispute Tests (Issue #1319) ──────────────────────────────────────────────
 
 /// Helper: creates a stream with an arbiter configured via force_stream.
+#[allow(clippy::too_many_arguments)]
 fn create_escrow_stream(
     env: &Env,
     client: &StreamContractClient<'_>,
@@ -3288,7 +3289,7 @@ fn test_initiate_dispute_emits_event() {
         .iter()
         .rev()
         .find_map(|(_, t, d)| {
-            let t_vec: soroban_sdk::Vec<soroban_sdk::Val> = t.clone().into();
+            let t_vec: soroban_sdk::Vec<soroban_sdk::Val> = t.clone();
             if let Ok(sym) = Symbol::try_from_val(&env, &t_vec.get(0).unwrap()) {
                 if sym == Symbol::new(&env, "dispute_initiated") {
                     return Some((t, d));
@@ -3491,7 +3492,7 @@ fn test_resolve_dispute_emits_event() {
         .iter()
         .rev()
         .find_map(|(_, t, d)| {
-            let t_vec: soroban_sdk::Vec<soroban_sdk::Val> = t.clone().into();
+            let t_vec: soroban_sdk::Vec<soroban_sdk::Val> = t.clone();
             if let Ok(sym) = Symbol::try_from_val(&env, &t_vec.get(0).unwrap()) {
                 if sym == Symbol::new(&env, "dispute_resolved") {
                     return Some((t, d));

--- a/contracts/stream_contract/src/types.rs
+++ b/contracts/stream_contract/src/types.rs
@@ -23,7 +23,6 @@ pub enum DisputeState {
     Resolved,
 }
 
-
 /// Status of a payment stream.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/contracts/stream_contract/src/types.rs
+++ b/contracts/stream_contract/src/types.rs
@@ -1,5 +1,29 @@
 use soroban_sdk::{contracttype, Address};
 
+/// Data stored when a dispute is initiated.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisputeInitiatedData {
+    pub initiator: Address,
+    pub timestamp: u64,
+}
+
+/// State of a dispute on an escrow-enabled stream.
+///
+/// Streams with an assigned `arbiter` can enter dispute resolution,
+/// freezing accrual until the arbiter splits the remaining funds.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DisputeState {
+    /// No dispute has been raised.
+    None,
+    /// A dispute has been initiated — stores initiator + timestamp.
+    Initiated(DisputeInitiatedData),
+    /// The arbiter has resolved the dispute.
+    Resolved,
+}
+
+
 /// Status of a payment stream.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -61,6 +85,11 @@ pub struct Stream {
     pub paused_at: Option<u64>,
     /// Current status of the stream. Always set.
     pub status: StreamStatus,
+    /// Optional arbiter address for escrow-enabled dispute resolution.
+    /// When set, the stream supports multi-signature dispute cancellation.
+    pub arbiter: Option<Address>,
+    /// If a dispute is active, stores its state. `None` means no dispute.
+    pub dispute_state: DisputeState,
 }
 
 /// Input for atomic batch stream creation.


### PR DESCRIPTION
## Summary

Implements arbitrated dispute resolution for escrow-enabled payment streams, as specified in Issue #1319.

## Changes

### `types.rs`
- Added `DisputeInitiatedData` struct (stores initiator address + timestamp)
- Added `DisputeState` enum: `None | Initiated(DisputeInitiatedData) | Resolved`
- Added `arbiter: Option<Address>` and `dispute_state: DisputeState` fields to `Stream`

### `errors.rs`
- `NoArbiterConfigured` (17) — stream has no arbiter set
- `DisputeAlreadyActive` (18) — dispute already in progress
- `NoActiveDispute` (19) — no dispute to resolve
- `InvalidDisputeSplit` (20) — payouts do not sum to remaining deposit
- `DisputeInProgress` (21) — blocks unilateral cancel during dispute

### `events.rs`
- `DisputeInitiatedEvent` — emitted on `initiate_dispute`
- `DisputeResolvedEvent` — emitted on `resolve_dispute`

### `lib.rs`
- `create_escrow_stream` — creates stream with an assigned arbiter
- `initiate_dispute` — either sender or recipient can freeze the stream
- `resolve_dispute` — arbiter splits remaining deposit atomically
- `cancel_stream` — guarded against active disputes (`DisputeInProgress`)

### `test.rs`
- 10+ tests: happy path, event emission, unauthorized access, invalid split, double-dispute, cancel blocking

## Test Results

```
test result: ok. 140 passed; 0 failed; 0 ignored
```

Closes #1319